### PR TITLE
Add padding to tertiaryText

### DIFF
--- a/src/components/ListItem/ListItem.less
+++ b/src/components/ListItem/ListItem.less
@@ -41,6 +41,7 @@
   line-height: 25px;
   position: relative;
   top: -7px;
+  padding-right: 30px;
 }
 
 .ms-ListItem-tertiaryText {


### PR DESCRIPTION
Add a bit of padding to keep the tertiaryText from overlapping the metaText on custom ListItem builds
