### PR TITLE
Remove unnecessary comment block from z-index variables

### DIFF
--- a/src/less/_Fabric.ZIndex.Variables.less
+++ b/src/less/_Fabric.ZIndex.Variables.less
@@ -30,39 +30,3 @@
 @ms-zIndex-Dialog:         @ms-zIndex-3;
 @ms-zIndex-PeoplePicker:   @ms-zIndex-3;
 @ms-zIndex-Dropdown:       @ms-zIndex-4;
-
-
-
-// Original z-indexes
-//
-// The values aren't important, but we'll want to
-// keep the relative positioning the same most likely.
-//
-// Each component that uses z-index should have a variable
-// for its 'base' layer. Other z-indexes within that component
-// can then add or subtract to position themselves relatively.
-//
-// .ms-Callout--arrowRight:before      -1
-// .ms-Callout--arrowRight:after        1
-// .ms-Callout-close                  500
-// .ms-Callout-header                 100
-//
-// .ms-ContextualMenu.is-open          99
-//
-// .ms-DatePicker-datePicker           10
-// .ms-DatePicker-headerToggleView     99
-//
-// .ms-Dialog                         300
-// .ms-Dialog-main                    999
-// .ms-Dialog--close                  500
-// .ms-Dialog-header                  100
-//
-// .ms-Dropdown-items                  99
-//
-// .ms-Overlay                        998
-//
-// .ms-Panel                           10
-// .ms-Panel-main                     999
-//
-// .ms-PeoplePicker-results            99
-// .ms-PeoplePicker-resultAction        1


### PR DESCRIPTION
Remove unnecessary comment block from z-index variables file.
