### PR TITLE
Inherit line-height for icons

### DIFF
--- a/src/sass/_Fabric.Icons.scss
+++ b/src/sass/_Fabric.Icons.scss
@@ -14,7 +14,6 @@
   font-family: 'FabricMDL2Icons';
   font-style: normal;
   font-weight: normal;
-  line-height: inherit;
   speak: none;
 }
 

--- a/src/sass/_Fabric.Icons.scss
+++ b/src/sass/_Fabric.Icons.scss
@@ -14,7 +14,7 @@
   font-family: 'FabricMDL2Icons';
   font-style: normal;
   font-weight: normal;
-  line-height: 1;
+  line-height: inherit;
   speak: none;
 }
 


### PR DESCRIPTION
This PR sets line-height to 'inherit', so that icons act like any other text span rather than setting an explicit line height.