### PR TITLE
Update NPM, Bower, and NuGet packages for Fabric Core 3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
-  "name": "office-ui-fabric",
+  "name": "office-ui-fabric-core",
   "author": "Office UI Fabric Team",
   "version": "3.0.0",
   "description": "The front-end framework for building experiences for Office 365.",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OfficeDev/Office-UI-Fabric"
+    "url": "https://github.com/OfficeDev/Office-UI-Fabric-Core"
   },
   "main": [
     "dist/css/fabric.css",

--- a/gulp/modules/Config.js
+++ b/gulp/modules/Config.js
@@ -70,16 +70,16 @@ var Config = function() {
     };
   this.typescriptProject = Plugins.tsc.createProject(this.typescriptConfig);
 	this.nugetConfig = {
-		id: "OfficeUIFabric",
-		title: "Office UI Fabric",
+		id: "OfficeUIFabricCore",
+		title: "Office UI Fabric Core",
 		version: pkg.version,
 		authors: "Microsoft Corporation",
 		owners: "Microsoft Corporation",
 		description: "Fabric is a responsive, mobile-first, front-end framework, designed to make it quick and simple for you to create web experiences using the Office Design Language. It’s easy to get up and running with Fabric—whether you’re creating a new Office experience from scratch or adding new features to an existing one.",
 		summary: "The front-end framework for building experiences for Office and Office 365.",
 		language: "en-us",
-		projectUrl: "https://github.com/OfficeDev/Office-UI-Fabric",
-		licenseUrl: "https://github.com/OfficeDev/Office-UI-Fabric/blob/master/LICENSE",
+		projectUrl: "https://github.com/OfficeDev/Office-UI-Fabric-Core",
+		licenseUrl: "https://github.com/OfficeDev/Office-UI-Fabric-Core/blob/master/LICENSE",
 		copyright: "Copyright (c) Microsoft Corporation",
 		requireLicenseAcceptance: true,
 		tags: "Microsoft UI Fabric CSS",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "office-ui-fabric",
+  "name": "office-ui-fabric-core",
   "author": "Office UI Fabric Team",
   "version": "3.0.0",
   "description": "The front-end framework for building experiences for Office 365.",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OfficeDev/Office-UI-Fabric"
+    "url": "https://github.com/OfficeDev/Office-UI-Fabric-Core"
   },
   "private": false,
   "devDependencies": {


### PR DESCRIPTION
This PR updates the configuration for NPM, Bower, and NuGet to reflect the change in name "Office UI Fabric" to "Office UI Fabric Core" and the version bump to 3.0.0.