### PR TITLE
Disable Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "4.1"
+notifications:
+    email: false


### PR DESCRIPTION
This PR updates the Travis configuration to prevent it from sending emails on build success/failure. These emails are just noise, as the build result is displayed right in the PR itself.