### PR TITLE
Update Bower configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,11 +8,7 @@
     "type": "git",
     "url": "https://github.com/OfficeDev/Office-UI-Fabric"
   },
-  "main": [
-    "dist/css/fabric.css",
-    "dist/css/fabric.components.css",
-    "dist/js/jquery.fabric.js"
-  ],
+  "main": "dist/css/fabric.css",
   "private": false,
   "ignore": [
     "node_modules",


### PR DESCRIPTION
Fixes #763. This PR updates the Bower configuration to include only `fabric.css`.