### PR TITLE
Enable safe minifying to remove aggressive optimizations

### DIFF
--- a/gulp/FabricBuild.js
+++ b/gulp/FabricBuild.js
@@ -59,7 +59,9 @@ gulp.task('Fabric-buildStyles', function () {
             .pipe(Plugins.csscomb())
             .pipe(gulp.dest(Config.paths.distCSS))
             .pipe(Plugins.rename('fabric.min.css'))
-            .pipe(Plugins.cssMinify())
+            .pipe(Plugins.cssMinify({
+                safe: true
+            }))
             .pipe(Plugins.header(Banners.getBannerTemplate(), Banners.getBannerData()))
             .pipe(Plugins.header(Banners.getCSSCopyRight(), Banners.getBannerData()))
             .pipe(gulp.dest(Config.paths.distCSS));


### PR DESCRIPTION
Right now, safe minifying is not enabled in the minified build for core Fabric. This means that some of the more advanced optimizations, such as [reduce idents](http://cssnano.co/optimisations/#reduceidents), are crunching identifier names like keyframes (so `slideRightIn10` becomes `a`). This means that JS that tries to pivot off of `animationend ` for those keyframe names will not work.

This PR turns that feature on so that identifiers are not crunched. See CSSnano's documentation for other [advanced optimizations](http://cssnano.co/options/#optionssafe-bool) this feature enables.

Note that doing this does not actually change the output size of `fabric.min.css`--it remains at ~50k.