### PR TITLE
Fix SASS mixin for input-placeholders.

### DIFF
--- a/src/sass/_Fabric.Mixins.scss
+++ b/src/sass/_Fabric.Mixins.scss
@@ -228,12 +228,10 @@
 
 // Input placehoder
 @mixin input-placeholder {
-    &::-webkit-input-placeholder,
-    &::-moz-placeholder,
-    &:-moz-placeholder,
-    &:-ms-input-placeholder {
-        @content;
-    }
+    &::-webkit-input-placeholder  {@content}
+    &::-moz-placeholder           {@content}
+    &:-moz-placeholder            {@content}
+    &:-ms-input-placeholder       {@content}
 }
 
 // Animations


### PR DESCRIPTION
See http://www.codechewing.com/library/create-sass-mixin-for-styling-placeholders-css/ for information.

> It’s important that each vendor’s style is contained within a separate selector block of their own. If we were to merge the selectors together, then a browser which doesn’t understand one of the selectors will actually invalidate the entire line of selectors.