### PR TITLE
Add skype icons back to included icon set

### DIFF
--- a/src/sass/Fabric.Icons.Output.scss
+++ b/src/sass/Fabric.Icons.Output.scss
@@ -304,6 +304,9 @@
 .ms-Icon--PageAdd::before { @include ms-Icon--PageAdd }
 .ms-Icon--NumberedList::before { @include ms-Icon--NumberedList }
 .ms-Icon--Glimmer::before { @include ms-Icon--Glimmer }
+.ms-Icon--SkypeCheck::before { @include ms-Icon--SkypeCheck; }
+.ms-Icon--SkypeClock::before { @include ms-Icon--SkypeClock; }
+.ms-Icon--SkypeMinus::before { @include ms-Icon--SkypeMinus; }
 
 // Modifier: Place the icon in a circle.
 .ms-Icon--circle {

--- a/src/sass/_Fabric.Icons.scss
+++ b/src/sass/_Fabric.Icons.scss
@@ -308,6 +308,9 @@
 @mixin ms-Icon--PageAdd { content: "\EA1A"; }
 @mixin ms-Icon--NumberedList { content: "\EA1C"; }
 @mixin ms-Icon--Glimmer { content: "\ECF4"; }
+@mixin ms-Icon--SkypeCheck { content: "\EF80"; }
+@mixin ms-Icon--SkypeClock { content: "\EF81"; }
+@mixin ms-Icon--SkypeMinus { content: "\EF82"; }
 
 
 // Modifier: Place the icon in a circle.


### PR DESCRIPTION
The skype icons were included in office-ui-fabric-js but now with the icons of that repo removed, core needs to be updated with the icons.