### PR TITLE
Move icon size classes to output file

### DIFF
--- a/src/sass/Fabric.Icons.Output.scss
+++ b/src/sass/Fabric.Icons.Output.scss
@@ -13,7 +13,6 @@
   @include ms-Icon();
 }
 
-
 // Modifiers: Each of the icons.
 .ms-Icon--GlobalNavButton::before { @include ms-Icon--GlobalNavButton }
 .ms-Icon--MapPin::before { @include ms-Icon--MapPin }
@@ -311,4 +310,22 @@
 // Modifier: Place the icon in a circle.
 .ms-Icon--circle {
   @include ms-Icon--circle;
+}
+
+// Icon size classes
+
+.ms-Icon--xs {
+  @include ms-Icon--xs;
+}
+
+.ms-Icon--s {
+  @include ms-Icon--s;
+}
+
+.ms-Icon--m {
+  @include ms-Icon--m;
+}
+
+.ms-Icon--l {
+  @include ms-Icon--l;
 }

--- a/src/sass/_Fabric.Icons.scss
+++ b/src/sass/_Fabric.Icons.scss
@@ -351,24 +351,14 @@
   }
 }
 
-// Fabric Core Icon variables
+// Icon size variables
 $ms-icon-size-xs: 10px;
 $ms-icon-size-s: 12px;
 $ms-icon-size-m: 16px;
 $ms-icon-size-l: 20px;
 
-.ms-Icon--xs {
-  font-size: $ms-icon-size-xs;
-}
-
-.ms-Icon--s {
-  font-size: $ms-icon-size-s;
-}
-
-.ms-Icon--m {
-  font-size: $ms-icon-size-m;
-}
-
-.ms-Icon--l {
-  font-size: $ms-icon-size-l;
-}
+// Icon size mixins
+@mixin ms-Icon--xs { font-size: $ms-icon-size-xs; }
+@mixin ms-Icon--s { font-size: $ms-icon-size-s; }
+@mixin ms-Icon--m { font-size: $ms-icon-size-m; }
+@mixin ms-Icon--l { font-size: $ms-icon-size-l; }


### PR DESCRIPTION
Fixes #774

This PR adds mixins for the icon size modifiers, and moves the actual classes to the output file.