### PR TITLE
Remove high contrast link colors

### DIFF
--- a/src/sass/_Fabric.Color.Variables.scss
+++ b/src/sass/_Fabric.Color.Variables.scss
@@ -91,5 +91,3 @@ $ms-color-contrastBlackDisabled: #00ff00;
 $ms-color-contrastWhiteDisabled: #600000;
 $ms-color-contrastBlackSelected: #1AEBFF;
 $ms-color-contrastWhiteSelected: #37006E;
-$ms-color-contrastBlackLink: #8080ff;
-$ms-color-contrastWhiteLink: #00009F;


### PR DESCRIPTION
Remove high contrast link colors since the browser will handle link colors correctly. Colors used in Link.scss already removed, no other component is using these colors.