### PR TITLE
Added !default to variables

### DIFF
--- a/src/sass/_Fabric.Animations.scss
+++ b/src/sass/_Fabric.Animations.scss
@@ -10,12 +10,12 @@
 // The original class names are deprecated and will be removed in a future release.
 
 // Variables
-$ms-ease1:     cubic-bezier(0.1,0.9,0.2,1);
-$ms-ease2:     cubic-bezier(0.1,0.25,0.75,0.9);
-$ms-duration1: 0.167s;
-$ms-duration2: 0.267s;
-$ms-duration3: 0.367s;
-$ms-duration4: 0.467s;
+$ms-ease1:     cubic-bezier(0.1,0.9,0.2,1) !default;
+$ms-ease2:     cubic-bezier(0.1,0.25,0.75,0.9) !default;
+$ms-duration1: 0.167s !default;
+$ms-duration2: 0.267s !default;
+$ms-duration3: 0.367s !default;
+$ms-duration4: 0.467s !default;
 
 
 // Animation mixin

--- a/src/sass/_Fabric.Color.Variables.scss
+++ b/src/sass/_Fabric.Color.Variables.scss
@@ -8,86 +8,86 @@
 
 //== Theme Colors
 //
-$ms-color-themeDarker:     #004578;
-$ms-color-themeDark:       #005a9e;
-$ms-color-themeDarkAlt:    #106ebe;
-$ms-color-themePrimary:    #0078d7;
-$ms-color-themeSecondary:  #2488d8;
-$ms-color-themeTertiary:   #69afe5;
-$ms-color-themeLight:      #b3d6f2;
-$ms-color-themeLighter:    #deecf9;
-$ms-color-themeLighterAlt: #eff6fc;
+$ms-color-themeDarker:     #004578 !default;
+$ms-color-themeDark:       #005a9e !default;
+$ms-color-themeDarkAlt:    #106ebe !default;
+$ms-color-themePrimary:    #0078d7 !default;
+$ms-color-themeSecondary:  #2488d8 !default;
+$ms-color-themeTertiary:   #69afe5 !default;
+$ms-color-themeLight:      #b3d6f2 !default;
+$ms-color-themeLighter:    #deecf9 !default;
+$ms-color-themeLighterAlt: #eff6fc !default;
 
 
 //== Grayscale Colors
 //
-$ms-color-black:                 #000000;
-$ms-color-neutralDark:           #212121;
-$ms-color-neutralPrimary:        #333333;
-$ms-color-neutralPrimaryAlt:     #3C3C3C;
-$ms-color-neutralSecondary:      #666666;
-$ms-color-neutralSecondaryAlt:   #767676;
-$ms-color-neutralTertiary:       #a6a6a6;
-$ms-color-neutralTertiaryAlt:    #c8c8c8;
-$ms-color-neutralQuaternary:     #d0d0d0;
-$ms-color-neutralQuaternaryAlt:  #dadada;
-$ms-color-neutralLight:          #eaeaea;
-$ms-color-neutralLighter:        #f4f4f4;
-$ms-color-neutralLighterAlt:     #f8f8f8;
-$ms-color-white:                 #ffffff;
+$ms-color-black:                 #000000 !default;
+$ms-color-neutralDark:           #212121 !default;
+$ms-color-neutralPrimary:        #333333 !default;
+$ms-color-neutralPrimaryAlt:     #3C3C3C !default;
+$ms-color-neutralSecondary:      #666666 !default;
+$ms-color-neutralSecondaryAlt:   #767676 !default;
+$ms-color-neutralTertiary:       #a6a6a6 !default;
+$ms-color-neutralTertiaryAlt:    #c8c8c8 !default;
+$ms-color-neutralQuaternary:     #d0d0d0 !default;
+$ms-color-neutralQuaternaryAlt:  #dadada !default;
+$ms-color-neutralLight:          #eaeaea !default;
+$ms-color-neutralLighter:        #f4f4f4 !default;
+$ms-color-neutralLighterAlt:     #f8f8f8 !default;
+$ms-color-white:                 #ffffff !default;
 
 //== Translucent Colors
 //
-$ms-color-blackTranslucent40:  rgba(0,0,0,.4);
-$ms-color-whiteTranslucent40:  rgba(255,255,255,.4);
+$ms-color-blackTranslucent40:  rgba(0,0,0,.4) !default;
+$ms-color-whiteTranslucent40:  rgba(255,255,255,.4) !default;
 
 
 //== Core brand and accent colors
 //
-$ms-color-yellow:        #ffb900;
-$ms-color-yellowLight:   #fff100;
-$ms-color-orange:        #d83b01;
-$ms-color-orangeLight:   #ea4300;
-$ms-color-orangeLighter: #ff8c00;
-$ms-color-redDark:       #a80000;
-$ms-color-red:           #e81123;
-$ms-color-magentaDark:   #5c005c;
-$ms-color-magenta:       #b4009e;
-$ms-color-magentaLight:  #e3008c;
-$ms-color-purpleDark:    #32145a;
-$ms-color-purple:        #5c2d91;
-$ms-color-purpleLight:   #b4a0ff;
-$ms-color-blueDark:      #002050;
-$ms-color-blueMid:       #00188f;
-$ms-color-blue:          #0078d7;
-$ms-color-blueLight:     #00bcf2;
-$ms-color-tealDark:      #004b50;
-$ms-color-teal:          #008272;
-$ms-color-tealLight:     #00b294;
-$ms-color-greenDark:     #004b1c;
-$ms-color-green:         #107c10;
-$ms-color-greenLight:    #bad80a;
+$ms-color-yellow:        #ffb900 !default;
+$ms-color-yellowLight:   #fff100 !default;
+$ms-color-orange:        #d83b01 !default;
+$ms-color-orangeLight:   #ea4300 !default;
+$ms-color-orangeLighter: #ff8c00 !default;
+$ms-color-redDark:       #a80000 !default;
+$ms-color-red:           #e81123 !default;
+$ms-color-magentaDark:   #5c005c !default;
+$ms-color-magenta:       #b4009e !default;
+$ms-color-magentaLight:  #e3008c !default;
+$ms-color-purpleDark:    #32145a !default;
+$ms-color-purple:        #5c2d91 !default;
+$ms-color-purpleLight:   #b4a0ff !default;
+$ms-color-blueDark:      #002050 !default;
+$ms-color-blueMid:       #00188f !default;
+$ms-color-blue:          #0078d7 !default;
+$ms-color-blueLight:     #00bcf2 !default;
+$ms-color-tealDark:      #004b50 !default;
+$ms-color-teal:          #008272 !default;
+$ms-color-tealLight:     #00b294 !default;
+$ms-color-greenDark:     #004b1c !default;
+$ms-color-green:         #107c10 !default;
+$ms-color-greenLight:    #bad80a !default;
 
 
 //== Message colors
 //
-$ms-color-info:              $ms-color-neutralSecondaryAlt;
-$ms-color-infoBackground:    $ms-color-neutralLighter;
-$ms-color-success:           $ms-color-green;
-$ms-color-successBackground: #dff6dd;
-$ms-color-severeWarning:     $ms-color-orange;
-$ms-color-severeWarningBackground: #fed9cc;
-$ms-color-alert:             $ms-color-severeWarning;   // Deprecated: Use $ms-color-severeWarning
-$ms-color-alertBackground:   $ms-color-severeWarningBackground; // Deprecated: Use $ms-color-severeWarningBackground
-$ms-color-warning:           $ms-color-neutralSecondaryAlt;
-$ms-color-warningBackground: #fff4ce;
-$ms-color-error:             $ms-color-redDark;
-$ms-color-errorBackground:   #fde7e9;
+$ms-color-info:              $ms-color-neutralSecondaryAlt !default;
+$ms-color-infoBackground:    $ms-color-neutralLighter !default;
+$ms-color-success:           $ms-color-green !default;
+$ms-color-successBackground: #dff6dd !default;
+$ms-color-severeWarning:     $ms-color-orange !default;
+$ms-color-severeWarningBackground: #fed9cc !default;
+$ms-color-alert:             $ms-color-severeWarning !default;   // Deprecated: Use $ms-color-severeWarning
+$ms-color-alertBackground:   $ms-color-severeWarningBackground !default; // Deprecated: Use $ms-color-severeWarningBackground
+$ms-color-warning:           $ms-color-neutralSecondaryAlt !default;
+$ms-color-warningBackground: #fff4ce !default;
+$ms-color-error:             $ms-color-redDark !default;
+$ms-color-errorBackground:   #fde7e9 !default;
 
 
 //== High contrast colors
 //
-$ms-color-contrastBlackDisabled: #00ff00;
-$ms-color-contrastWhiteDisabled: #600000;
-$ms-color-contrastBlackSelected: #1AEBFF;
-$ms-color-contrastWhiteSelected: #37006E;
+$ms-color-contrastBlackDisabled: #00ff00 !default;
+$ms-color-contrastWhiteDisabled: #600000 !default;
+$ms-color-contrastBlackSelected: #1AEBFF !default;
+$ms-color-contrastWhiteSelected: #37006E !default;

--- a/src/sass/_Fabric.Responsive.Variables.scss
+++ b/src/sass/_Fabric.Responsive.Variables.scss
@@ -10,22 +10,22 @@
 //
 
 // Small screen / phone (320px - 479px)
-$ms-screen-sm-min:       320px;
+$ms-screen-sm-min:       320px !default;
 
 // Medium screen / tablet (480px - 639px)
-$ms-screen-md-min:       480px;
+$ms-screen-md-min:       480px !default;
 
 // Large screen / tablet (640px - 1023px)
-$ms-screen-lg-min:       640px;
+$ms-screen-lg-min:       640px !default;
 
 // Extra large screen / tablet (1024px - 1365px)
-$ms-screen-xl-min:       1024px;
+$ms-screen-xl-min:       1024px !default;
 
 // Extra extra large screen / desktop (1366px - 1919px)
-$ms-screen-xxl-min:      1366px;
+$ms-screen-xxl-min:      1366px !default;
 
 // Extra extra extra large screen / desktop (1920px and up)
-$ms-screen-xxxl-min:     1920px;
+$ms-screen-xxxl-min:     1920px !default;
 
 // Set all maxes since order matters in SASS
 $ms-screen-sm-max:       ($ms-screen-md-min - 1);

--- a/src/sass/_Fabric.Typography.Fonts.scss
+++ b/src/sass/_Fabric.Typography.Fonts.scss
@@ -7,18 +7,18 @@
 
 
 // Font weights.
-$ms-font-name: "Segoe UI";
+$ms-font-name: "Segoe UI" !default;
 
 
 // Font paths.
-$ms-font-directory:         "https://appsforoffice.microsoft.com/fabric/fonts";
-$ms-font-path-arabic:       "SegoeUI-Arabic";
-$ms-font-path-cyrillic:     "SegoeUI-Cyrillic";
-$ms-font-path-easteuropean: "SegoeUI-EastEuropean";
-$ms-font-path-greek:        "SegoeUI-Greek";
-$ms-font-path-hebrew:       "SegoeUI-Hebrew";
-$ms-font-path-vietnamese:   "SegoeUI-Vietnamese";
-$ms-font-path-westeuropean: "SegoeUI-WestEuropean";
+$ms-font-directory:         "https://appsforoffice.microsoft.com/fabric/fonts" !default;
+$ms-font-path-arabic:       "SegoeUI-Arabic" !default;
+$ms-font-path-cyrillic:     "SegoeUI-Cyrillic" !default;
+$ms-font-path-easteuropean: "SegoeUI-EastEuropean" !default;
+$ms-font-path-greek:        "SegoeUI-Greek" !default;
+$ms-font-path-hebrew:       "SegoeUI-Hebrew" !default;
+$ms-font-path-vietnamese:   "SegoeUI-Vietnamese" !default;
+$ms-font-path-westeuropean: "SegoeUI-WestEuropean" !default;
 
 
 /*

--- a/src/sass/_Fabric.Typography.Language.Overrides.scss
+++ b/src/sass/_Fabric.Typography.Language.Overrides.scss
@@ -34,17 +34,17 @@
 }
 
 // Variables for each of the non-distributed (native) font stacks.
-$ms-font-stack-japanese: 'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, $ms-font-system-base;
-$ms-font-stack-korean: 'Malgun Gothic', Gulim, $ms-font-system-base;
-$ms-font-stack-chinese-simplified: 'Microsoft Yahei', Verdana, Simsun, $ms-font-system-base;
-$ms-font-stack-chinese-traditional: 'Microsoft Jhenghei', Pmingliu, $ms-font-system-base;
-$ms-font-stack-hindi: 'Nirmala UI', $ms-font-system-base;
+$ms-font-stack-japanese: 'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, $ms-font-system-base !default;
+$ms-font-stack-korean: 'Malgun Gothic', Gulim, $ms-font-system-base !default;
+$ms-font-stack-chinese-simplified: 'Microsoft Yahei', Verdana, Simsun, $ms-font-system-base !default;
+$ms-font-stack-chinese-traditional: 'Microsoft Jhenghei', Pmingliu, $ms-font-system-base !default;
+$ms-font-stack-hindi: 'Nirmala UI', $ms-font-system-base !default;
 
 // Variables for each of the web font stacks.
-$ms-font-stack-arabic:        'Segoe UI Arabic', $ms-font-family-base;
-$ms-font-stack-cyrillic:      'Segoe UI Cyrillic', $ms-font-family-base;
-$ms-font-stack-eastEuropean:  'Segoe UI EastEuropean', $ms-font-family-base;
-$ms-font-stack-greek:         'Segoe UI Greek', $ms-font-family-base;
-$ms-font-stack-hebrew:        'Segoe UI Hebrew', $ms-font-family-base;
-$ms-font-stack-vietnamese:    'Segoe UI Vietnamese', $ms-font-family-base;
-$ms-font-stack-leelawadee:    'Leelawadee UI', 'Kmer UI', $ms-font-family-base;
+$ms-font-stack-arabic:        'Segoe UI Arabic', $ms-font-family-base !default;
+$ms-font-stack-cyrillic:      'Segoe UI Cyrillic', $ms-font-family-base !default;
+$ms-font-stack-eastEuropean:  'Segoe UI EastEuropean', $ms-font-family-base !default;
+$ms-font-stack-greek:         'Segoe UI Greek', $ms-font-family-base !default;
+$ms-font-stack-hebrew:        'Segoe UI Hebrew', $ms-font-family-base !default;
+$ms-font-stack-vietnamese:    'Segoe UI Vietnamese', $ms-font-family-base !default;
+$ms-font-stack-leelawadee:    'Leelawadee UI', 'Kmer UI', $ms-font-family-base !default;

--- a/src/sass/_Fabric.Typography.Variables.scss
+++ b/src/sass/_Fabric.Typography.Variables.scss
@@ -5,25 +5,25 @@
 // --------------------------------------------------
 // Fabric Core Typography variables
 
-$ms-font-system-base: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-$ms-font-family-base:  'Segoe UI WestEuropean', $ms-font-system-base;
+$ms-font-system-base: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif !default;
+$ms-font-family-base:  'Segoe UI WestEuropean', $ms-font-system-base !default;
 
-$ms-font-weight-light:     100;
-$ms-font-weight-regular:   400;
-$ms-font-weight-semilight: 300;
-$ms-font-weight-semibold:  600;
+$ms-font-weight-light:     100 !default;
+$ms-font-weight-regular:   400 !default;
+$ms-font-weight-semilight: 300 !default;
+$ms-font-weight-semibold:  600 !default;
 
 
 //== Type sizes
 //
 
-$ms-font-size-su:          42px;
-$ms-font-size-xxl:         28px;
-$ms-font-size-xl:          21px;
-$ms-font-size-l:           17px;
-$ms-font-size-m-plus:      15px;
-$ms-font-size-m:           14px;
-$ms-font-size-s-plus:      13px;
-$ms-font-size-s:           12px;
-$ms-font-size-xs:          11px;
-$ms-font-size-mi:          10px;
+$ms-font-size-su:          42px !default;
+$ms-font-size-xxl:         28px !default;
+$ms-font-size-xl:          21px !default;
+$ms-font-size-l:           17px !default;
+$ms-font-size-m-plus:      15px !default;
+$ms-font-size-m:           14px !default;
+$ms-font-size-s-plus:      13px !default;
+$ms-font-size-s:           12px !default;
+$ms-font-size-xs:          11px !default;
+$ms-font-size-mi:          10px !default;

--- a/src/sass/_Fabric.ZIndex.Variables.scss
+++ b/src/sass/_Fabric.ZIndex.Variables.scss
@@ -7,26 +7,26 @@
 
 
 // Base Layer Variables
-$ms-zIndex-0: 0;
-$ms-zIndex-1: 100;
-$ms-zIndex-2: 200;
-$ms-zIndex-3: 300;
-$ms-zIndex-4: 400;
-$ms-zIndex-5: 500;
+$ms-zIndex-0: 0 !default;
+$ms-zIndex-1: 100 !default;
+$ms-zIndex-2: 200 !default;
+$ms-zIndex-3: 300 !default;
+$ms-zIndex-4: 400 !default;
+$ms-zIndex-5: 500 !default;
 
 // Base Layer Modifier Variables
-$ms-zIndex-back:   0;
-$ms-zIndex-middle: 5;
-$ms-zIndex-front:  10;
+$ms-zIndex-back:   0 !default;
+$ms-zIndex-middle: 5 !default;
+$ms-zIndex-front:  10 !default;
 
 
 // Fabric Component Base Layer Assignments
 
-$ms-zIndex-Callout:        $ms-zIndex-1;
-$ms-zIndex-ContextualMenu: $ms-zIndex-1;
-$ms-zIndex-Overlay:        $ms-zIndex-2;
-$ms-zIndex-Panel:          $ms-zIndex-3;
-$ms-zIndex-DatePicker:     $ms-zIndex-3;
-$ms-zIndex-Dialog:         $ms-zIndex-3;
-$ms-zIndex-PeoplePicker:   $ms-zIndex-3;
-$ms-zIndex-Dropdown:       $ms-zIndex-4;
+$ms-zIndex-Callout:        $ms-zIndex-1 !default;
+$ms-zIndex-ContextualMenu: $ms-zIndex-1 !default;
+$ms-zIndex-Overlay:        $ms-zIndex-2 !default;
+$ms-zIndex-Panel:          $ms-zIndex-3 !default;
+$ms-zIndex-DatePicker:     $ms-zIndex-3 !default;
+$ms-zIndex-Dialog:         $ms-zIndex-3 !default;
+$ms-zIndex-PeoplePicker:   $ms-zIndex-3 !default;
+$ms-zIndex-Dropdown:       $ms-zIndex-4 !default;


### PR DESCRIPTION
As discussed in issue #805, Office UI Fabric currently does not support customization, which is necessary if customers have their own branding. 
This pull requests adds the [`!default`](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_) flag to the variables defined in the Office UI Fabric. This flag tells SASS to leave the value of a variable unchanged, if it is already defined. With this approach, you can define your own values in a separate file and include them in the build process of your custom Office UI Fabric. Only those values will be set to their default values, that have not been defined previously in your own variables file.

Your custom SASS file might look like the following:
``` SASS
@import "fabricVariables"; //Includes your variables
@import "fabric"; //Main Fabric.scss file (located elsewhere, included in the sass build process)
@import "fabric.components"; //Main SCSS for components (located elsewhere, included in the sass build process)

//Your additional customizations
```