### PR TITLE
Update the URLs for the CDN to the production location

### DIFF
--- a/src/sass/Fabric.Icons.Font.Output.scss
+++ b/src/sass/Fabric.Icons.Font.Output.scss
@@ -13,8 +13,8 @@
 
 @font-face {
   font-family: 'FabricMDL2Icons';
-  src: url('https://spoppe-a.akamaihd.net/files/fabric/assets/icons/fabricmdl2icons.woff') format('woff'),
-       url('https://spoppe-a.akamaihd.net/files/fabric/assets/icons/fabricmdl2icons.ttf') format('truetype');
+  src: url('https://spoprod-a.akamaihd.net/files/fabric/assets/icons/fabricmdl2icons.woff') format('woff'),
+       url('https://spoprod-a.akamaihd.net/files/fabric/assets/icons/fabricmdl2icons.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/sass/_Fabric.Brand.Icons.scss
+++ b/src/sass/_Fabric.Brand.Icons.scss
@@ -1,8 +1,8 @@
 // Images Path for Product Icons
-$productImagesPath: "https://spoppe-a.akamaihd.net/files/fabric/assets/brand-icons/product/png";
+$productImagesPath: "https://spoprod-a.akamaihd.net/files/fabric/assets/brand-icons/product/png";
 
 // Images Path for Document Icons
-$documentImagesPath: "https://spoppe-a.akamaihd.net/files/fabric/assets/brand-icons/document/png";
+$documentImagesPath: "https://spoprod-a.akamaihd.net/files/fabric/assets/brand-icons/document/png";
 
 // Icon Names
 $productIconList: access excel infopath office onedrive onenote outlook powerpoint project sharepoint visio word;

--- a/src/sass/_Fabric.Typography.Fonts.scss
+++ b/src/sass/_Fabric.Typography.Fonts.scss
@@ -11,7 +11,7 @@ $ms-font-name: "Segoe UI" !default;
 
 
 // Font paths.
-$ms-font-directory:         "https://spoppe-a.akamaihd.net/files/fabric/assets/fonts/" !default;
+$ms-font-directory:         "https://spoprod-a.akamaihd.net/files/fabric/assets/fonts/" !default;
 $ms-font-path-arabic:       "segoeui-arabic" !default;
 $ms-font-path-cyrillic:     "segoeui-cyrillic" !default;
 $ms-font-path-easteuropean: "segoeui-easteuropean" !default;


### PR DESCRIPTION
In previous pull requests I used the testing URL for the CDN rather than the production one. This updates Fabric to pull the web font and icons from the production location.