### PR TITLE
Update CDN paths to support HTTP/2

### DIFF
--- a/src/sass/Fabric.Icons.Font.Output.scss
+++ b/src/sass/Fabric.Icons.Font.Output.scss
@@ -13,8 +13,8 @@
 
 @font-face {
   font-family: 'FabricMDL2Icons';
-  src: url('https://spoprod-a.akamaihd.net/files/fabric/assets/icons/fabricmdl2icons.woff') format('woff'),
-       url('https://spoprod-a.akamaihd.net/files/fabric/assets/icons/fabricmdl2icons.ttf') format('truetype');
+  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.woff') format('woff'),
+       url('https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/sass/_Fabric.Brand.Icons.scss
+++ b/src/sass/_Fabric.Brand.Icons.scss
@@ -1,8 +1,8 @@
 // Images Path for Product Icons
-$productImagesPath: "https://spoprod-a.akamaihd.net/files/fabric/assets/brand-icons/product/png";
+$productImagesPath: "https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/png";
 
 // Images Path for Document Icons
-$documentImagesPath: "https://spoprod-a.akamaihd.net/files/fabric/assets/brand-icons/document/png";
+$documentImagesPath: "https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/png";
 
 // Icon Names
 $productIconList: access excel infopath office onedrive onenote outlook powerpoint project sharepoint visio word;

--- a/src/sass/_Fabric.Typography.Fonts.scss
+++ b/src/sass/_Fabric.Typography.Fonts.scss
@@ -11,7 +11,7 @@ $ms-font-name: "Segoe UI" !default;
 
 
 // Font paths.
-$ms-font-directory:         "https://spoprod-a.akamaihd.net/files/fabric/assets/fonts/" !default;
+$ms-font-directory:         "https://static2.sharepointonline.com/files/fabric/assets/fonts/" !default;
 $ms-font-path-arabic:       "segoeui-arabic" !default;
 $ms-font-path-cyrillic:     "segoeui-cyrillic" !default;
 $ms-font-path-easteuropean: "segoeui-easteuropean" !default;


### PR DESCRIPTION
The new CDN path supports the [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) protocol, which allows for loading multiple files in a single request. This improves performance when requesting multiple files from the same server.

The old CDN paths will continue to work (they point to the same server) so this is not a breaking change.