### PR TITLE
Add WOFF2 version of the icon font

### DIFF
--- a/src/sass/Fabric.Icons.Font.Output.scss
+++ b/src/sass/Fabric.Icons.Font.Output.scss
@@ -13,7 +13,8 @@
 
 @font-face {
   font-family: 'FabricMDL2Icons';
-  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.woff') format('woff'),
+  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.woff2') format('woff2'),
+       url('https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.woff') format('woff'),
        url('https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
Improves performance by using a WOFF2 version of the icon font, which is 22% smaller, for [browsers which support this format](http://caniuse.com/#feat=woff2).

**Do not merge until the [WOFF2 font file](https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons.woff2) is available on the CDN.**