### PR TITLE
Update remaining link to new CDN

### DIFF
--- a/src/documentation/templates/modules/components/DocumentationPageHeader.html
+++ b/src/documentation/templates/modules/components/DocumentationPageHeader.html
@@ -5,7 +5,7 @@
   <title>Office Fabric UI Core Documentation</title>
   <link rel="stylesheet" href="../../css/fabric.css">
   <link rel="stylesheet" href="../docs.css">
-  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/2.6.1/fabric.components.min.css">
+  <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/2.6.2/css/fabric.components.min.css">
 </head>
 <body>
 <div id="body-content">


### PR DESCRIPTION
Found one remaining reference to the old CDN in the documentation. This PR updates it to the new CDN.