### PR TITLE
Update to gulp-sass 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
-    "gulp-sass": "^3.0.0",
+    "gulp-sass": "^3.1.0",
     "gulp-size": "^1.0.0",
     "gulp-template": "^3.0.0",
     "gulp-tslint": "^7.0.1",


### PR DESCRIPTION
Fixes #898

Updates to the latest version of gulp-sass, which seems to resolve the intermittent 'stack level too deep' error we've been getting during the build.