### PR TITLE
Add a mixin to ensure font family is inherited

### DIFF
--- a/src/sass/mixins/_General.Mixins.scss
+++ b/src/sass/mixins/_General.Mixins.scss
@@ -244,8 +244,18 @@
 @mixin ms-Fabric {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+  @include ms-inherit-font-family();
   color: $ms-color-neutralPrimary;
   font-family: $ms-font-family-west-european;
+}
+
+// Set the font-family to 'inherit' for elements where the browser
+// styles commonly conflict with the font-family that we want.
+@mixin ms-inherit-font-family() {
+  button,
+  input {
+    font-family: inherit;
+  }
 }
 
 @mixin ms-focus-border($padding: 0, $color: $ms-color-neutralSecondary) {


### PR DESCRIPTION
Adds a new mixin, `@ms-inherit-font-family`, which sets `font-family: inherit` on button and input elements. This is essentially a very minimal [CSS normalize](http://necolas.github.io/normalize.css/). We can add more elements to it over time as needed. It's used only within the `ms-Fabric` wrapper, ensuring that we don't break any styles outside of our boundary.

The need for this was discovered while doing a test build of Fabric React with the changes that will be included in the next release of Fabric Core. The font-family wasn't being correctly inherited into buttons and form fields because the browser's default styles took precedence.

Before:
![image](https://cloud.githubusercontent.com/assets/1382445/22127846/9dcacab8-de52-11e6-8358-045f9d63450d.png)

After:
![image](https://cloud.githubusercontent.com/assets/1382445/22127804/710a20c8-de52-11e6-8b4f-cc6fc2af1c6c.png)
