### PR TITLE
Update to the latest value for theme light

### DIFF
--- a/src/sass/variables/_Color.Variables.scss
+++ b/src/sass/variables/_Color.Variables.scss
@@ -7,7 +7,7 @@ $ms-color-themeDarkAlt:    #106ebe !default;
 $ms-color-themePrimary:    #0078d7 !default;
 $ms-color-themeSecondary:  #2488d8 !default;
 $ms-color-themeTertiary:   #69afe5 !default;
-$ms-color-themeLight:      #b3d6f2 !default;
+$ms-color-themeLight:      #c7e0f4 !default;
 $ms-color-themeLighter:    #deecf9 !default;
 $ms-color-themeLighterAlt: #eff6fc !default;
 


### PR DESCRIPTION
It turns out that the spec we received way back had an incorrect color in it. This PR updates "theme light" to the correct color value.

![color-change](https://cloud.githubusercontent.com/assets/1382445/22524065/93244020-e876-11e6-80cb-63a15f75290f.png)
