### PR TITLE
Documentation: Format Markdown for 2.6.x

### DIFF
--- a/ghdocs/V2GETSTARTED.md
+++ b/ghdocs/V2GETSTARTED.md
@@ -1,9 +1,9 @@
-#Get started with Fabric 2.6.1
+# Get started with Fabric 2.6.1
 
 The last stable version of Fabric that included components was 2.6.1, and, although we recommend [Fabric React](https://github.com/OfficeDev/office-ui-fabric-react) or the existing Fabric Core, 2.6.1 and previous versions are still available via the CDN, package managers, and GitHub for cloning or downloading.
 
 
-###Download 
+### Download 
 The simplest way to get started is to add a copy of Fabric to your project.
 
 1. Download the source code zip file from the [2.6.1 release](https://github.com/OfficeDev/office-ui-fabric-core/releases/tag/2.6.1) (or earlier) on GitHub.
@@ -12,7 +12,7 @@ The simplest way to get started is to add a copy of Fabric to your project.
 4. If you're using components, add a reference to `fabric.components.css` after the `fabric.css` reference.
 
 
-###CDN
+### CDN
 If you prefer to have your project's assets stored on an external server, Fabric is available from the apps for Office CDN. To use it, include the following references in the `<head>` of your page.
 ```html
 <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/2.6.1/fabric.min.css">
@@ -22,32 +22,32 @@ If you prefer to have your project's assets stored on an external server, Fabric
 All previous versions through to 2.6.1 are available on the CDN. To reference a specific version, update the version number in the URL to match the one you want.
 
 
-###Package managers
+### Package managers
 Fabric 2.6.1 is available via Bower, npm, and NuGet.
 
-####Install with Bower
+#### Install with Bower
 To install Fabric using Bower, run the following command:
 ```
 $ bower install office-ui-fabric
 ```
 
-####Install with npm
+#### Install with npm
 To install Fabric using npm, run the following command:
 ```
 $ npm install office-ui-fabric
 ```
 
-####Install with NuGet Package Manager
+#### Install with NuGet Package Manager
 To install Fabric's NuGet package, run the following command in the [package manager console](http://docs.nuget.org/consume/package-manager-console):
 ```
 PM> Install-Package OfficeUIFabric
 ```
 
-###Clone and build locally
+### Clone and build locally
 Office UI Fabric uses [gulp](http://gulpjs.com/) to compile its styling, build and serve demos, and generate or watch other parts of the framework for changes. Use it to customize Fabric for your project, or to test changes you make to specific aspects of the toolkit.
 
 
-####Building Fabric
+#### Building Fabric
 
 Before you get started, make sure you have [node.js](https://nodejs.org/), [gulp](http://gulpjs.com/), and [git](https://git-scm.com/) installed. To build Fabric:
 
@@ -59,38 +59,38 @@ Before you get started, make sure you have [node.js](https://nodejs.org/), [gulp
 
 The built files will be in the `/dist/` folder.
 
-####Gulp tasks
+#### Gulp tasks
 
 You can test and work with Fabric locally using the tasks below.
 
-#####gulp
+##### gulp
 
 Builds everything incrementally. This will run slowly the first time and very quickly on subsequent runs. This task will build all parts of Fabric and move all changed files into `/dist/`. Every time you make changes, re-run this task.
 
-#####gulp watch
+##### gulp watch
 
 Builds and watches everything. After running this once, your builds will be a lot faster. Now if you make a change anything anywhere in Fabric, only that area/section/file will get built/changed/moved.
 
 Using this, you can also view the localhost documentation site with examples for all of the components.
 
-#####gulp watch-debug
+##### gulp watch-debug
 
 This task is similar to `gulp watch` except you can now get a readout of what files are in the pipe. This will be helpful to make sure that the build is working properly. 
 
-#####gulp watch-sass
+##### gulp watch-sass
 
 Builds and watches everything but builds only Sass versions of our core library files.
 
-#####gulp watch-sass-debug
+##### gulp watch-sass-debug
 
 Builds and watches everything but uses the Sass versions of the files and gives a readout of files in the pipe.
 
-#####gulp Bundles
+##### gulp Bundles
 
 Builds all bundles specified in `gulp/modules/Config.js`. View more details in the [Bundling](https://github.com/OfficeDev/Office-UI-Fabric/blob/master/ghdocs/BUNDLING.md)
 
 
-####Starter template
+#### Starter template
 
 The following starter template represents the minimum recommended HTML structure for an app or add-in that uses Fabric. Copy the code into your project to start working with a basic Fabric document.
 


### PR DESCRIPTION
Just add space for markdown, to make it easy to read.

![image](https://cloud.githubusercontent.com/assets/3375461/24563800/87c3e9a4-1604-11e7-9249-b2f958422e87.png)
