### PR TITLE
Set the default/base font size in the ms-Fabric wrapper

### DIFF
--- a/src/sass/mixins/_General.Mixins.scss
+++ b/src/sass/mixins/_General.Mixins.scss
@@ -248,6 +248,7 @@
   @include ms-inherit-font-family();
   color: $ms-color-neutralPrimary;
   font-family: $ms-font-family-west-european;
+  font-size: $ms-font-size-m;
 }
 
 // Set the font-family to 'inherit' for elements where the browser


### PR DESCRIPTION
Fixes #938 by setting the font size to 14px (medium) in the `ms-Fabric` wrapper component. This is **potentially a breaking change** if an app was previously inheriting font size from a parent element. We should mark it as a breaking change in the release of Fabric Core 7.0.0 to bring awareness to this issue.