### PR TITLE
Revert gulp-changed to ^1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-batch": "^1.0.5",
-    "gulp-changed": "^2.0.0",
+    "gulp-changed": "^1.3.0",
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-connect": "^5.0.0",
     "gulp-css-flipper": "^1.0.2",


### PR DESCRIPTION
After this version was bumped by Greenkeeper (see PR #919) the builds fail with this error:

```
/home/travis/build/OfficeDev/office-ui-fabric-core/node_modules/gulp-changed/index.js:2
const fs = require('fs');
^^^^^
SyntaxError: Use of const in strict mode.
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at new Plugins (/home/travis/build/OfficeDev/office-ui-fabric-core/gulp/modules/Plugins.js:10:19)
    at Object.<anonymous> (/home/travis/build/OfficeDev/office-ui-fabric-core/gulp/modules/Plugins.js:41:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

This PR reverts the change from #919.