### PR TITLE
Add the current icon font version to the CDN URLs

### DIFF
--- a/src/sass/_Icon.Definitions.scss
+++ b/src/sass/_Icon.Definitions.scss
@@ -13,6 +13,7 @@
 @font-face {
   $icon-font-family: 'FabricMDL2Icons';
   $icon-font-name: 'fabricmdl2icons';
+  $icon-font-version: '2.17';
 
   @if variable_exists(do-scope-styles) {
     $icon-font-family: 'FabricMDL2Icons-' + $ms-fabric-version-major; 
@@ -20,9 +21,9 @@
   }
 
   font-family: $icon-font-family;
-  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff2?2.17') format('woff2'),
-       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff?2.17') format('woff'),
-       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.ttf?2.17') format('truetype');
+  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff2?#{$icon-font-version}') format('woff2'),
+       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff?#{$icon-font-version}') format('woff'),
+       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.ttf?#{$icon-font-version}') format('truetype');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/sass/_Icon.Definitions.scss
+++ b/src/sass/_Icon.Definitions.scss
@@ -20,9 +20,9 @@
   }
 
   font-family: $icon-font-family;
-  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff2') format('woff2'),
-       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff') format('woff'),
-       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.ttf') format('truetype');
+  src: url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff2?2.17') format('woff2'),
+       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.woff?2.17') format('woff'),
+       url('https://static2.sharepointonline.com/files/fabric/assets/icons/#{$icon-font-name}.ttf?2.17') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Fixes #955 by including the current icon font version as a query parameter. This will force the CDN to grab the 2.17 version of the font files, rather than serving up a cached copy of the previous version. Going forward, we should update these URLs whenever the icon font is updated.