### PR TITLE
Revert -ms-high-contrast-adjust: none in fabric core 7.0.0

### DIFF
--- a/src/sass/mixins/_General.Mixins.scss
+++ b/src/sass/mixins/_General.Mixins.scss
@@ -80,7 +80,6 @@
 // Base/wrapper component to set typography throughout the app.
 @mixin ms-Fabric {
   -moz-osx-font-smoothing: grayscale;
-  -ms-high-contrast-adjust: none;
   -webkit-font-smoothing: antialiased;
   @include ms-inherit-font-family();
   color: $ms-color-neutralPrimary;


### PR DESCRIPTION
This breaks the fabric high contrast for IE and Edge. We need to apply this on selected elements not on overall fabric wrapper.