### PR TITLE
Add Segoe UI as the primary fallback font

### DIFF
--- a/src/sass/variables/_Font.Variables.scss
+++ b/src/sass/variables/_Font.Variables.scss
@@ -4,7 +4,7 @@
 $ms-font-cdn-path: 'https://static2.sharepointonline.com/files/fabric/assets/fonts' !default;
 
 // Fallback fonts, if specified system or web fonts are unavailable.
-$ms-font-family-fallbacks: -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif !default;
+$ms-font-family-fallbacks: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif !default;
 
 // Language-specific font stacks.
 $ms-font-family-arabic:              'Segoe UI Web (Arabic)', $ms-font-family-fallbacks !default;


### PR DESCRIPTION
This PR adds Segoe UI to the list of fallback fonts. On systems that have Segoe UI, it will be preferred over the other fonts if the web font does not load.