### PR TITLE
Fix .md headers for BUILDING docs

### DIFF
--- a/ghdocs/BUILDING.md
+++ b/ghdocs/BUILDING.md
@@ -1,14 +1,14 @@
-#Building Fabric, gulp tasks, bundling, and the starter template
+# Building Fabric, gulp tasks, bundling, and the starter template
 
 Office UI Fabric uses [gulp](http://gulpjs.com/) to compile its styles. Use it to customize Fabric for your project, or to test changes you make to specific aspects of the toolkit.
 
-##Contents
+## Contents
 
 - [Building Fabric](#building-fabric)
 - [Gulp tasks](#gulp-tasks)
 - [Starter template](#starter-template)
 
-##Building Fabric
+## Building Fabric
 
 Before you get started, make sure you have [node.js](https://nodejs.org/), [gulp](http://gulpjs.com/), and [git](https://git-scm.com/) installed. To build Fabric:
 
@@ -19,35 +19,35 @@ Before you get started, make sure you have [node.js](https://nodejs.org/), [gulp
 
 The built files will be in the `/dist/` folder.
 
-##Gulp tasks
+## Gulp tasks
 
 You can test and work with Fabric locally using the tasks below.
 
-###gulp
+### gulp
 
 Builds everything incrementally. This will run slowly the first time and very quickly on subsequent runs. This task will build all parts of Fabric and move all changed files into `/dist/`. Every time you make changes, re-run this task.
 
-###gulp watch
+### gulp watch
 
 Builds and watches everything. After running this once, your builds will be a lot faster. Now if you make a change anything anywhere in Fabric, only that area/section/file will get built/changed/moved.
 
-###gulp watch-debug
+### gulp watch-debug
 
 This task is similar to `gulp watch` except you can now get a readout of what files are in the pipe. This will be helpful to make sure that the build is working properly. 
 
-###gulp watch-sass
+### gulp watch-sass
 
 Builds and watches everything but builds only Sass versions of our core library files.
 
-###gulp watch-sass-debug
+### gulp watch-sass-debug
 
 Builds and watches everything but uses the Sass versions of the files and gives a readout of files in the pipe.
 
-###gulp Bundles
+### gulp Bundles
 
 Builds all bundles specified in `gulp/modules/Config.js`. View more details in the [Bundling](https://github.com/OfficeDev/Office-UI-Fabric/blob/master/ghdocs/BUNDLING.md)
 
-##Starter template
+## Starter template
 
 The following starter template represents the minimum recommended HTML structure for an app or add-in that uses Fabric. Copy the code into your project to start working with a basic Fabric document.
 


### PR DESCRIPTION
Fixing some bad spacing in the BUILDING.md docs that were causing gross rendering.