### PR TITLE
Add mixins for min-width and max-width media queries

### DIFF
--- a/src/sass/mixins/_Responsive.Mixins.scss
+++ b/src/sass/mixins/_Responsive.Mixins.scss
@@ -1423,3 +1423,65 @@
     @include ms-margin-left(0);
   }
 }
+
+// Min-width media queries.
+@mixin ms-screen-sm-up  {
+  @media only screen and (min-width: $ms-screen-min-sm) {
+    @content;
+  }
+}
+
+@mixin ms-screen-md-up {
+  @media only screen and (min-width: $ms-screen-min-md) {
+    @content;
+  }
+}
+
+@mixin ms-screen-lg-up {
+  @media only screen and (min-width: $ms-screen-min-lg) {
+    @content;
+  }
+}
+
+@mixin ms-screen-xl-up {
+  @media only screen and (min-width: $ms-screen-min-xl) {
+    @content;
+  }
+}
+
+@mixin ms-screen-xxl-up {
+  @media only screen and (min-width: $ms-screen-min-xxl) {
+    @content;
+  }
+}
+
+// Max-width media queries.
+@mixin ms-screen-sm-down {
+  @media only screen and (max-width: $ms-screen-max-sm) {
+    @content;
+  }
+}
+
+@mixin ms-screen-md-down {
+  @media only screen and (max-width: $ms-screen-max-md) {
+    @content;
+  }
+}
+
+@mixin ms-screen-lg-down {
+  @media only screen and (max-width: $ms-screen-max-lg) {
+    @content;
+  }
+}
+
+@mixin ms-screen-xl-down {
+  @media only screen and (max-width: $ms-screen-max-xl) {
+    @content;
+  }
+}
+
+@mixin ms-screen-xxl-down {
+  @media only screen and (max-width: $ms-screen-max-xxl) {
+    @content;
+  }
+}

--- a/src/sass/mixins/_Responsive.Mixins.scss
+++ b/src/sass/mixins/_Responsive.Mixins.scss
@@ -1425,12 +1425,6 @@
 }
 
 // Min-width media queries.
-@mixin ms-screen-sm-up  {
-  @media only screen and (min-width: $ms-screen-min-sm) {
-    @content;
-  }
-}
-
 @mixin ms-screen-md-up {
   @media only screen and (min-width: $ms-screen-min-md) {
     @content;
@@ -1451,6 +1445,12 @@
 
 @mixin ms-screen-xxl-up {
   @media only screen and (min-width: $ms-screen-min-xxl) {
+    @content;
+  }
+}
+
+@mixin ms-screen-xxxl-up {
+  @media only screen and (min-width: $ms-screen-min-xxxl) {
     @content;
   }
 }


### PR DESCRIPTION
Fixes #864 by adding mixins for min-width and max-width media queries. These mixins are:
```
ms-screen-md-up
ms-screen-lg-up
ms-screen-xl-up
ms-screen-xxl-up
ms-screen-xxxl-up

ms-screen-sm-down
ms-screen-md-down
ms-screen-lg-down
ms-screen-xl-down
ms-screen-xxl-down
```

And can be used like so:
```
div {
  background-color: red;

  @include ms-screen-lg-up {
    background-color: blue;
  }
}
```