### PR TITLE
Remove borderColorTop-themePrimary classes and mixin

### DIFF
--- a/src/sass/_Color.scss
+++ b/src/sass/_Color.scss
@@ -433,9 +433,3 @@
 .ms-borderColor-greenLight {
   @include ms-borderColor-greenLight;
 }
-
-// Individual borders, by request
-.ms-borderColorTop-themePrimary,
-.ms-borderColorTop-themePrimary--hover:hover {
-  @include ms-borderColorTop-themePrimary;
-}

--- a/src/sass/mixins/_Color.Mixins.scss
+++ b/src/sass/mixins/_Color.Mixins.scss
@@ -410,9 +410,3 @@
 @mixin ms-borderColor-error {
   border-color: $ms-color-error;
 }
-
-
-// Individual borders, by request
-@mixin ms-borderColorTop-themePrimary {
-  border-top-color: $ms-color-themePrimary;
-}


### PR DESCRIPTION
Fixes #886 by removing the `borderColorTop-themePrimary` classes and mixin. While this would usually be considered a breaking change, these classes were never documented or widely used.