### PR TITLE
Ensure that textarea elements inherit font family

### DIFF
--- a/src/sass/mixins/_General.Mixins.scss
+++ b/src/sass/mixins/_General.Mixins.scss
@@ -91,7 +91,8 @@
 // styles commonly conflict with the font-family that we want.
 @mixin ms-inherit-font-family() {
   button,
-  input {
+  input,
+  textarea {
     font-family: inherit;
   }
 }


### PR DESCRIPTION
Fixes #993 by adding `textarea` to the list of elements that should inherit font family (rather than using the browser default) when placed inside the `ms-Fabric` wrapper class.