### PR TITLE
Fix alignment bug with ms-textAlignCenter class

### DIFF
--- a/src/sass/_Utility.scss
+++ b/src/sass/_Utility.scss
@@ -25,8 +25,18 @@
   @include ms-normalize;
 }
 
-// Use to set left, center, right text alignment styles 
-@include ms-textAlign(left, center, right);
+// Text alignments.
+.ms-textAlignLeft {
+  @include ms-text-align(left);
+}
+
+.ms-textAlignRight {
+  @include ms-text-align(right);
+}
+
+.ms-textAlignCenter {
+  text-align: center;
+}
 
 // Use to hide content while still making it readable by screen reader (Accessibility)
 .ms-screenReaderOnly {

--- a/src/sass/mixins/_General.Mixins.scss
+++ b/src/sass/mixins/_General.Mixins.scss
@@ -175,6 +175,7 @@
 // Generate text alignment classes, such as .ms-textAlignLeft 
 // @param [variable list] $alignments
 @mixin ms-textAlign($alignments...) {
+  @warn 'The ms-textAlign mixin has been deprecated and will be removed in a future release of Fabric Core.';
   @each $align in $alignments {
     $alignStr: inspect($align);
     .ms-textAlign#{to-upper-case(str-slice($alignStr, 1, 1)) + str-slice($alignStr, 2)} {


### PR DESCRIPTION
Fixes #1037 by updating the `ms-textAlign[alignment]` utilities to call the `ms-text-align()` mixins directly, where necessary. Deprecated the ms-textAlign() mixin as it's no longer needed.

Here is the final output:

```
[dir='ltr'] .ms-textAlignLeft {
  text-align: left;
}

[dir='rtl'] .ms-textAlignLeft {
  text-align: right;
}

[dir='ltr'] .ms-textAlignRight {
  text-align: right;
}

[dir='rtl'] .ms-textAlignRight {
  text-align: left;
}

.ms-textAlignCenter {
  text-align: center;
}
```