### PR TITLE
Remove translucent color variables

### DIFF
--- a/src/sass/variables/_Color.Variables.scss
+++ b/src/sass/variables/_Color.Variables.scss
@@ -27,10 +27,6 @@ $ms-color-neutralLighter:        #f4f4f4 !default;
 $ms-color-neutralLighterAlt:     #f8f8f8 !default;
 $ms-color-white:                 #ffffff !default;
 
-// Translucent
-$ms-color-blackTranslucent40:  rgba(0,0,0,.4) !default;
-$ms-color-whiteTranslucent40:  rgba(255,255,255,.4) !default;
-
 // Accent
 $ms-color-yellow:        #ffb900 !default;
 $ms-color-yellowLight:   #fff100 !default;


### PR DESCRIPTION
Fixes #874. Not considered a breaking change as these variables were never documented, or even used within classes or mixins.