### PR TITLE
Update to icons version 2.52

### DIFF
--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -1216,6 +1216,7 @@
   { "name": "VSTSAltLogo2", "unicode": "F383" },
   { "name": "VSTSLogo", "unicode": "F381" },
   { "name": "Waffle", "unicode": "ED89" },
+  { "name": "WaffleOffice365", "unicode": "F4E0" },
   { "name": "Warning", "unicode": "E7BA" },
   { "name": "Website", "unicode": "EB41" },
   { "name": "Weights", "unicode": "EADB" },

--- a/src/sass/_Icon.Definitions.scss
+++ b/src/sass/_Icon.Definitions.scss
@@ -13,7 +13,7 @@
 @font-face {
   $icon-font-family: 'FabricMDL2Icons';
   $icon-font-name: 'fabricmdl2icons';
-  $icon-font-version: '2.51';
+  $icon-font-version: '2.52';
 
   @if variable_exists(do-scope-styles) {
     $icon-font-family: 'FabricMDL2Icons-' + $ms-fabric-version-major; 

--- a/src/sass/mixins/_Icon.Mixins.scss
+++ b/src/sass/mixins/_Icon.Mixins.scss
@@ -1330,6 +1330,7 @@
 @mixin ms-Icon--VSTSAltLogo2 { content: $ms-icon-code-VSTSAltLogo2; }
 @mixin ms-Icon--VSTSLogo { content: $ms-icon-code-VSTSLogo; }
 @mixin ms-Icon--Waffle { content: $ms-icon-code-Waffle; }
+@mixin ms-Icon--WaffleOffice365 { content: $ms-icon-code-WaffleOffice365; }
 @mixin ms-Icon--Warning { content: $ms-icon-code-Warning; }
 @mixin ms-Icon--Website { content: $ms-icon-code-Website; }
 @mixin ms-Icon--Weights { content: $ms-icon-code-Weights; }

--- a/src/sass/variables/_Icon.Variables.scss
+++ b/src/sass/variables/_Icon.Variables.scss
@@ -1224,6 +1224,7 @@ $ms-icon-code-VSTSAltLogo1: '\F382';
 $ms-icon-code-VSTSAltLogo2: '\F383';
 $ms-icon-code-VSTSLogo: '\F381';
 $ms-icon-code-Waffle: '\ED89';
+$ms-icon-code-WaffleOffice365: '\F4E0';
 $ms-icon-code-Warning: '\E7BA';
 $ms-icon-code-Website: '\EB41';
 $ms-icon-code-Weights: '\EADB';
@@ -2474,6 +2475,7 @@ $ms-icon-map: (
   'VSTSAltLogo2': $ms-icon-code-VSTSAltLogo2,
   'VSTSLogo': $ms-icon-code-VSTSLogo,
   'Waffle': $ms-icon-code-Waffle,
+  'WaffleOffice365': $ms-icon-code-WaffleOffice365,
   'Warning': $ms-icon-code-Warning,
   'Website': $ms-icon-code-Website,
   'Weights': $ms-icon-code-Weights,


### PR DESCRIPTION
Fixes #1048 by updating to version 2.52 of the icons. This adds one new icon:

![image](https://user-images.githubusercontent.com/1382445/31776196-ac4bc820-b49f-11e7-8c59-f92946cddf17.png)
`WaffleOffice365`