### PR TITLE
Add Segoe UI Bold

### DIFF
--- a/src/documentation/templates/models/FontWeightModel.json
+++ b/src/documentation/templates/models/FontWeightModel.json
@@ -15,6 +15,10 @@
     {
       "class": "ms-fontWeight-semibold",
       "name": "Semi Bold"
+    },
+    {
+      "class": "ms-fontWeight-bold",
+      "name": "Bold"
     }
   ]
 }

--- a/src/sass/_Font.scss
+++ b/src/sass/_Font.scss
@@ -92,6 +92,10 @@
   @include ms-fontWeight-semibold;
 }
 
+.ms-fontWeight-bold {
+  @include ms-fontWeight-bold;
+}
+
 // Font sizes
 .ms-fontSize-su {
   @include ms-fontSize-su;

--- a/src/sass/mixins/_Font.Mixins.scss
+++ b/src/sass/mixins/_Font.Mixins.scss
@@ -42,6 +42,14 @@
     font-weight: $ms-font-weight-semibold;
     font-style: normal;
   }
+
+  @font-face {
+    font-family: $font-family-name;
+    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-bold.woff2') format('woff2'),
+         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-bold.woff') format('woff');
+    font-weight: $ms-font-weight-bold;
+    font-style: normal;
+  }
 }
 
 // Generate overrides to set font-family based on the lang attribute.
@@ -138,6 +146,10 @@
 
 @mixin ms-fontWeight-semibold {
   font-weight: $ms-font-weight-semibold;
+}
+
+@mixin ms-fontWeight-bold {
+  font-weight: $ms-font-weight-bold;
 }
 
 // Font sizes

--- a/src/sass/variables/_Font.Variables.scss
+++ b/src/sass/variables/_Font.Variables.scss
@@ -28,6 +28,7 @@ $ms-font-weight-light:     100 !default;
 $ms-font-weight-semilight: 300 !default;
 $ms-font-weight-regular:   400 !default;
 $ms-font-weight-semibold:  600 !default;
+$ms-font-weight-bold:      700 !default;
 
 // Sizes
 $ms-font-size-su:       42px !default;


### PR DESCRIPTION
Fixed #1051 by adding the bold weight of Segoe UI.

This includes a variable mapping bold to 700, which matches browsers' [default font weights](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Values). Mixins and a new `.ms-fontWeight-bold` class are included as well.