### PR TITLE
Add directionality mixin for background position

### DIFF
--- a/src/sass/mixins/_Directionality.Mixins.scss
+++ b/src/sass/mixins/_Directionality.Mixins.scss
@@ -32,6 +32,29 @@
 // Common CSS property mixins with support for RTL.
 // Use to automatically create RTL versions of your properties.
 
+// Background direction.
+@mixin ms-background-position($alignment) {
+  @if $alignment == left {
+    @include ms-LTR {
+      background-position: left;
+    }
+
+    @include ms-RTL {
+      background-position: right;
+    }
+  } @else if $alignment == right {
+    @include ms-LTR {
+      background-position: right;
+    }
+
+    @include ms-RTL {
+      background-position: left;
+    }
+  } @else {
+    background-position: $alignment;
+  }
+}
+
 // Border styles.
 @mixin ms-border-color($top, $right, $bottom, $left) {
   border-color: $top $right $bottom $left;


### PR DESCRIPTION
Fixes #1061 by adding a directionality mixin for `background-position`. See [this CodePen](https://codepen.io/mikewheaton/pen/oodEMz) for a demonstration.

This supports basic `left` and `right` arguments. If it's requested in the future, we may want to support more complex arguments like `10% 50%`, `left 20%`, `20em 80%`, etc.