### PR TITLE
Update localized fonts to include "UI" in names

### DIFF
--- a/src/documentation/templates/modules/content/styles-localization.html
+++ b/src/documentation/templates/modules/content/styles-localization.html
@@ -35,7 +35,7 @@
     <tr>
         <td role="gridcell">Japanese</td>
         <td role="gridcell">ja</td>
-        <td role="gridcell">'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka</td>
+        <td role="gridcell">'Yu Gothic UI', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka</td>
         <td role="gridcell" lang="ja">アップロードするファイルをここにドラッグ</td>
     </tr>
     <tr>
@@ -47,13 +47,13 @@
     <tr>
         <td role="gridcell">Chinese (simplified)</td>
         <td role="gridcell">zh-hans</td>
-        <td role="gridcell">'Microsoft Yahei', Verdana, Simsun</td>
+        <td role="gridcell">'Microsoft Yahei UI', Verdana, Simsun</td>
         <td role="gridcell" lang="zh-hans">将文件拖到此处以上传</td>
     </tr>
     <tr>
         <td role="gridcell">Chinese (traditional)</td>
         <td role="gridcell">zh-hant</td>
-        <td role="gridcell">'Microsoft Jhenghei', Pmingliu</td>
+        <td role="gridcell">'Microsoft Jhenghei UI', Pmingliu</td>
         <td role="gridcell" lang="zh-hant">拖曳檔案到這裡以上傳</td>
     </tr>
     <tr>

--- a/src/sass/variables/_Font.Variables.scss
+++ b/src/sass/variables/_Font.Variables.scss
@@ -8,14 +8,14 @@ $ms-font-family-fallbacks: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Robot
 
 // Language-specific font stacks.
 $ms-font-family-arabic:              'Segoe UI Web (Arabic)', $ms-font-family-fallbacks !default;
-$ms-font-family-chinese-simplified:  'Microsoft Yahei', Verdana, Simsun, $ms-font-family-fallbacks !default;
-$ms-font-family-chinese-traditional: 'Microsoft Jhenghei', Pmingliu, $ms-font-family-fallbacks !default;
+$ms-font-family-chinese-simplified:  'Microsoft Yahei UI', Verdana, Simsun, $ms-font-family-fallbacks !default;
+$ms-font-family-chinese-traditional: 'Microsoft Jhenghei UI', Pmingliu, $ms-font-family-fallbacks !default;
 $ms-font-family-cyrillic:            'Segoe UI Web (Cyrillic)', $ms-font-family-fallbacks !default;
 $ms-font-family-east-european:       'Segoe UI Web (East European)', $ms-font-family-fallbacks !default;
 $ms-font-family-greek:               'Segoe UI Web (Greek)', $ms-font-family-fallbacks !default;
 $ms-font-family-hebrew:              'Segoe UI Web (Hebrew)', $ms-font-family-fallbacks !default;
 $ms-font-family-hindi:               'Nirmala UI', $ms-font-family-fallbacks !default;
-$ms-font-family-japanese:            'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, $ms-font-family-fallbacks !default;
+$ms-font-family-japanese:            'Yu Gothic UI', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, $ms-font-family-fallbacks !default;
 $ms-font-family-korean:              'Malgun Gothic', Gulim, $ms-font-family-fallbacks !default;
 $ms-font-family-lao:                 'Leelawadee UI Web', 'Lao UI', DokChampa, $ms-font-family-fallbacks !default;
 $ms-font-family-selawik:             'Selawik Web', $ms-font-family-fallbacks !default;


### PR DESCRIPTION
Fixes #1072 by adding "UI" to the font names for Yu Gothic, Microsoft Yahei, and Microsoft Jhenghei. This matches the change made in Fabric React by [PR #3481](https://github.com/OfficeDev/office-ui-fabric-react/pull/3481).