### PR TITLE
BrandIcon: Update to latest document icons

### DIFF
--- a/src/sass/_BrandIcon.scss
+++ b/src/sass/_BrandIcon.scss
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
-@include ms-brand-icon-classes(1);
+@include ms-brand-icon-classes('1');
 @include ms-brand-icon-size-classes();
 
 // Pixel Ratio 1.5
 @media only screen and (min-resolution: 144dpi) {
-  @include ms-brand-icon-classes(1_5);
+  @include ms-brand-icon-classes('1_5');
 }
 
 // Pixel Ratio 2
 @media only screen and (min-resolution: 192dpi)  {
-  @include ms-brand-icon-classes(2);
+  @include ms-brand-icon-classes('2');
 }
 
 // Pixel Ratio 3
 @media only screen and (min-resolution: 288dpi) {
-  @include ms-brand-icon-classes(3);
+  @include ms-brand-icon-classes('3');
 }

--- a/src/sass/_BrandIcon.scss
+++ b/src/sass/_BrandIcon.scss
@@ -17,3 +17,92 @@
 @media only screen and (min-resolution: 288dpi) {
   @include ms-brand-icon-classes('3');
 }
+
+// The 'onepkg' and 'xls' icons have been deprecated. These classes will be removed in
+// a future release. Until then, they are mapped to 'one' and 'xlsx'.
+
+.ms-BrandIcon--onepkg.ms-BrandIcon--icon16 {
+  background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16/one.png);
+}
+.ms-BrandIcon--onepkg.ms-BrandIcon--icon48 {
+  background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48/one.png);
+}
+.ms-BrandIcon--onepkg.ms-BrandIcon--icon96 {
+  background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96/one.png);
+}
+
+.ms-BrandIcon--xls.ms-BrandIcon--icon16 {
+  background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16/xlsx.png);
+}
+.ms-BrandIcon--xls.ms-BrandIcon--icon48 {
+  background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48/xlsx.png);
+}
+.ms-BrandIcon--xls.ms-BrandIcon--icon96 {
+  background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96/xlsx.png);
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi) {
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon16 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16_1.5x/one.png);
+  }
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon48 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48_1.5x/one.png);
+  }
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon96 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96_1.5x/one.png);
+  }
+
+  .ms-BrandIcon--xls.ms-BrandIcon--icon16 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16_1.5x/xlsx.png);
+  }
+  .ms-BrandIcon--xls.ms-BrandIcon--icon48 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48_1.5x/xlsx.png);
+  }
+  .ms-BrandIcon--xls.ms-BrandIcon--icon96 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96_1.5x/xlsx.png);
+  }
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi) {
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon16 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16_2x/one.png);
+  }
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon48 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48_2x/one.png);
+  }
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon96 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96_2x/one.png);
+  }
+
+  .ms-BrandIcon--xls.ms-BrandIcon--icon16 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16_2x/xlsx.png);
+  }
+  .ms-BrandIcon--xls.ms-BrandIcon--icon48 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48_2x/xlsx.png);
+  }
+  .ms-BrandIcon--xls.ms-BrandIcon--icon96 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96_2x/xlsx.png);
+  }
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 3), only screen and (min-resolution: 288dpi) {
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon16 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16_3x/one.png);
+  }
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon48 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48_3x/one.png);
+  }
+  .ms-BrandIcon--onepkg.ms-BrandIcon--icon96 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96_3x/one.png);
+  }
+
+  .ms-BrandIcon--xls.ms-BrandIcon--icon16 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/16_3x/xlsx.png);
+  }
+  .ms-BrandIcon--xls.ms-BrandIcon--icon48 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/48_3x/xlsx.png);
+  }
+  .ms-BrandIcon--xls.ms-BrandIcon--icon96 {
+    background-image: url(https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/96_3x/xlsx.png);
+  }
+}

--- a/src/sass/mixins/_BrandIcon.Mixins.scss
+++ b/src/sass/mixins/_BrandIcon.Mixins.scss
@@ -4,22 +4,40 @@
 @mixin ms-brand-icon-classes($retina) {
 	@each $icon in $ms-brand-icon-product-icons {
 		.ms-BrandIcon--#{$icon} {
-			@include ms-brand-icon-sizes($icon, $retina, $ms-brand-icon-product-images-path);
+			@include ms-brand-icon-product-sizes($icon, $retina, $ms-brand-icon-product-images-path);
 		}
 	}
 
 	@each $icon in $ms-brand-icon-document-icons {
 		.ms-BrandIcon--#{$icon} {
-			@include ms-brand-icon-sizes($icon, $retina, $ms-brand-icon-document-images-path);
+			@include ms-brand-icon-document-sizes($icon, $retina, $ms-brand-icon-document-images-path);
 		}
 	}
 }
 
-// Generate size classes for each icon
-@mixin ms-brand-icon-sizes($icon, $retina, $images-path) {
+// Generate size classes for each product icon
+@mixin ms-brand-icon-product-sizes($icon, $retina, $images-path) {
 	@each $size in $ms-brand-icon-sizes {
 		&.ms-BrandIcon--icon#{$size} {
 			background-image: url(#{$images-path}/#{$icon}_#{$size}x#{$retina}.png);
+		}
+	}
+}
+
+// Generate size classes for each document icon
+@mixin ms-brand-icon-document-sizes($icon, $retina, $images-path) {
+	$scaleSuffix: '';
+	@if $retina == '1' {
+		$scaleSuffix: '';
+	} @else if $retina == '1_5' {
+		$scaleSuffix: '_1.5x';
+	} @else {
+		$scaleSuffix: '_#{$retina}x';
+	}
+
+	@each $size in $ms-brand-icon-sizes {
+		&.ms-BrandIcon--icon#{$size} {
+			background-image: url(#{$images-path}/#{$size}#{$scaleSuffix}/#{$icon}.png);
 		}
 	}
 }

--- a/src/sass/variables/_BrandIcon.Variables.scss
+++ b/src/sass/variables/_BrandIcon.Variables.scss
@@ -2,11 +2,11 @@
 
 // Image paths
 $ms-brand-icon-product-images-path:   'https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/png';
-$ms-brand-icon-document-images-path:  'https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/png';
+$ms-brand-icon-document-images-path:  'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types';
 
 // Names
 $ms-brand-icon-product-icons:  access excel infopath office onedrive onenote outlook powerpoint project sharepoint visio word;
-$ms-brand-icon-document-icons: accdb csv docx dotx mpp mpt odp ods odt one onepkg onetoc potx ppsx pptx pub vsdx vssx vstx xls xlsx xltx xsn;
+$ms-brand-icon-document-icons: accdb archive audio code csv docset docx dotx email exe folder font genericfile html link listitem model mpp mpt odp ods odt one onetoc pdf photo potx ppsx pptx pub rtf sharedfolder spo sysfile txt vector video vsdx vssx vstx xlsx xltx xml xsn zip;
 
 // Sizes
 $ms-brand-icon-sizes: 16 48 96;


### PR DESCRIPTION
Partially addresses #1088 by updating the `ms-BrandIcon` component to support the latest set of document icons. You can view the previous, updated, and new icons in [this CodePen](https://codepen.io/mikewheaton/pen/ZvrvMW).

## Deprecated icons
The `onepkg` and `xls` document icons do not exist in the new set. These have been temporarily mapped to the `one` and `xls` icons to match the [mappings in Fabric React](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/file-type-icons/src/FileTypeIconMap.ts). These classes will be removed in a future release.

## New icons
24 new product icons have been added:
- archive
- audio
- code
- docset
- email
- exe
- folder
- font
- genericfile
- html
- link
- listitem
- model
- pdf
- photo
- rtf
- sharedfolder
- spo
- sysfile
- txt
- vector
- video
- xml
- zip