### PR TITLE
Add Fluent grays

### DIFF
--- a/src/documentation/templates/models/NeutralColorsModel.json
+++ b/src/documentation/templates/models/NeutralColorsModel.json
@@ -5,198 +5,184 @@
       "hex": "#000000",
       "fontClass": "ms-fontColor-black",
       "bgClass": "ms-bgColor-black",
-      "borderClass": "ms-borderColor-black",
-      "contrastBgs": [
-        {
-          "class": "ms-bgColor-neutralLight",
-          "ratio": "17:5:1"
-        },
-        {
-          "class": "ms-bgColor-neutralLighter",
-          "ratio": "19:9:1"
-        },
-        {
-          "class": "ms-bgColor-neutralLightAlt",
-          "ratio": "19:8:1"
-        },
-        {
-          "class": "ms-bgColor-themeLight",
-          "ratio": "15:4:1"
-        },
-        {
-          "class": "ms-bgColor-themeLighter",
-          "ratio": "17:5:1"
-        },
-        {
-          "class": "ms-bgColor-themeLighterAlt",
-          "ratio": "19:3:1"
-        },
-        {
-          "class": "ms-bgColor-white",
-          "ratio": "21:1"
-        }
-      ]
+      "borderClass": "ms-borderColor-black"
     },
     {
-      "name": "Neutral Dark",
-      "hex": "#212121",
-      "fontClass": "ms-fontColor-neutralDark",
-      "bgClass": "ms-bgColor-neutralDark",
-      "borderClass": "ms-borderColor-neutralDark"
-    },
-     {
-      "name": "Neutral Primary",
-      "hex": "#333333",
-      "fontClass": "ms-fontColor-neutralPrimary",
-      "bgClass": "ms-bgColor-neutralPrimary",
-      "borderClass": "ms-borderColor-neutralPrimary",
-      "contrastBgs": [
-        {
-          "class": "ms-bgColor-neutralLight",
-          "ratio": "10:5:1"
-        },
-        {
-          "class": "ms-bgColor-neutralLighter",
-          "ratio": "11:5:1"
-        },
-        {
-          "class": "ms-bgColor-neutralLightAlt",
-          "ratio": "11:9:1"
-        },
-        {
-          "class": "ms-bgColor-themeLight",
-          "ratio": "9:3:1"
-        },
-        {
-          "class": "ms-bgColor-themeLighterAlt",
-          "ratio": "11:6:1"
-        },
-        {
-          "class": "ms-bgColor-white",
-          "ratio": "12:6:1"
-        }
-      ]
+      "name": "Gray220",
+      "hex": "#11100f",
+      "fontClass": "ms-fontColor-gray220",
+      "bgClass": "ms-bgColor-gray220",
+      "borderClass": "ms-borderColor-gray220"
     },
     {
-      "name": "Neutral Primary Alt",
-      "hex": "#3C3C3C",
-      "fontClass": "ms-fontColor-neutralPrimaryAlt",
-      "bgClass": "ms-bgColor-neutralPrimaryAlt",
-      "borderClass": "ms-borderColor-neutralPrimaryAlt"
+      "name": "Gray210",
+      "hex": "#161514",
+      "fontClass": "ms-fontColor-gray210",
+      "bgClass": "ms-bgColor-gray210",
+      "borderClass": "ms-borderColor-gray210"
     },
     {
-      "name": "Neutral Secondary",
-      "hex": "#666666",
-      "fontClass": "ms-fontColor-neutralSecondary",
-      "bgClass": "ms-bgColor-neutralSecondary",
-      "borderClass": "ms-borderColor-neutralSecondary",
-      "contrastBgs": [
-        {
-          "class": "ms-bgColor-neutralLight",
-          "ratio": "4:8:1"
-        },
-        {
-          "class": "ms-bgColor-neutralLighter",
-          "ratio": "5:2:1"
-        },
-        {
-          "class": "ms-bgColor-neutralLightAlt",
-          "ratio": "5:4:1"
-        },
-        {
-          "class": "ms-bgColor-themeLighter",
-          "ratio": "4:8:1"
-        },
-        {
-          "class": "ms-bgColor-themeLighterAlt",
-          "ratio": "5:27:1"
-        },
-        {
-          "class": "ms-bgColor-white",
-          "ratio": "5:7:1"
-        }
-      ]
+      "name": "Gray200",
+      "hex": "#1b1a19",
+      "fontClass": "ms-fontColor-gray200",
+      "bgClass": "ms-bgColor-gray200",
+      "borderClass": "ms-borderColor-gray200"
     },
     {
-      "name": "Neutral Secondary Alt",
-      "hex": "#767676",
-      "fontClass": "ms-fontColor-neutralSecondaryAlt",
-      "bgClass": "ms-bgColor-neutralSecondaryAlt",
-      "borderClass": "ms-borderColor-neutralSecondaryAlt",
-      "contrastBgs": [
-        {
-          "class": "ms-bgColor-white",
-          "ratio": "4:5:1"
-        }
-      ]
+      "name": "Gray190",
+      "hex": "#201f1e",
+      "fontClass": "ms-fontColor-gray190",
+      "bgClass": "ms-bgColor-gray190",
+      "borderClass": "ms-borderColor-gray190"
     },
     {
-      "name": "Neutral Tertiary",
-      "hex": "#A6A6A6",
-      "customNameColor": "ms-fontColor-black",
-      "fontClass": "ms-fontColor-neutralTertiary",
-      "bgClass": "ms-bgColor-neutralTertiary",
-      "borderClass": "ms-borderColor-neutralTertiary"
+      "name": "Gray180",
+      "hex": "#252423",
+      "fontClass": "ms-fontColor-gray180",
+      "bgClass": "ms-bgColor-gray180",
+      "borderClass": "ms-borderColor-gray180"
     },
     {
-      "name": "Neutral Tertiary Alt",
-      "customNameColor": "ms-fontColor-black",
-      "hex": "#C8C8C8",
-      "fontClass": "ms-fontColor-neutralTertiaryAlt",
-      "bgClass": "ms-bgColor-neutralTertiaryAlt",
-      "borderClass": "ms-borderColor-neutralTertiaryAlt"
+      "name": "Gray170",
+      "hex": "#292827",
+      "fontClass": "ms-fontColor-gray170",
+      "bgClass": "ms-bgColor-gray170",
+      "borderClass": "ms-borderColor-gray170"
     },
     {
-      "name": "Neutral Quaternary",
-      "hex": "#D0D0D0",
-      "customNameColor": "ms-fontColor-black",
-      "fontClass": "ms-fontColor-neutralQuaternary",
-      "bgClass": "ms-bgColor-neutralQuaternary",
-      "borderClass": "ms-borderColor-neutralQuaternary"
+      "name": "Gray160",
+      "hex": "#323130",
+      "fontClass": "ms-fontColor-gray160",
+      "bgClass": "ms-bgColor-gray160",
+      "borderClass": "ms-borderColor-gray160"
     },
     {
-      "name": "Neutral Quaternary Alt",
-      "customNameColor": "ms-fontColor-black",
-      "hex": "#DADADA",
-      "fontClass": "ms-fontColor-neutralQuaternaryAlt",
-      "bgClass": "ms-bgColor-neutralQuaternaryAlt",
-      "borderClass": "ms-borderColor-neutralQuaternaryAlt"
+      "name": "Gray150",
+      "hex": "#3b3a39",
+      "fontClass": "ms-fontColor-gray150",
+      "bgClass": "ms-bgColor-gray150",
+      "borderClass": "ms-borderColor-gray150"
     },
     {
-      "name": "Neutral Light",
-      "hex": "#EAEAEA",
-      "customNameColor": "ms-fontColor-black",
-      "fontClass": "ms-fontColor-neutralLight",
-      "bgClass": "ms-bgColor-neutralLight",
-      "borderClass": "ms-borderColor-neutralLight",
-      "secondBgClass": "ms-bgColor-neutralPrimaryAlt"
+      "name": "Gray140",
+      "hex": "#484644",
+      "fontClass": "ms-fontColor-gray140",
+      "bgClass": "ms-bgColor-gray140",
+      "borderClass": "ms-borderColor-gray140"
     },
     {
-      "name": "Neutral Lighter",
-      "hex": "#004578",
-      "customNameColor": "ms-fontColor-black",
-      "fontClass": "ms-fontColor-neutralLighter",
-      "bgClass": "ms-bgColor-neutralLighter",
-      "borderClass": "ms-borderColor-neutralLighter",
-      "secondBgClass": "ms-bgColor-neutralPrimaryAlt"
+      "name": "Gray130",
+      "hex": "#605e5c",
+      "fontClass": "ms-fontColor-gray130",
+      "bgClass": "ms-bgColor-gray130",
+      "borderClass": "ms-borderColor-gray130"
     },
     {
-      "name": "Neutral Lighter Alt",
-      "hex": "#F8F8F8",
-      "customNameColor": "ms-fontColor-black",
-      "fontClass": "ms-fontColor-neutralLighterAlt",
-      "bgClass": "ms-bgColor-neutralLighterAlt",
-      "borderClass": "ms-borderColor-neutralLighterAlt",
-      "secondBgClass": "ms-bgColor-neutralPrimary"
+      "name": "Gray120",
+      "hex": "#797775",
+      "fontClass": "ms-fontColor-gray120",
+      "bgClass": "ms-bgColor-gray120",
+      "borderClass": "ms-borderColor-gray120"
     },
     {
-      "name": "White",
-      "hex": "#FFFFFF",
-      "customNameColor": "ms-fontColor-black",
+      "name": "Gray110",
+      "hex": "#8a8886",
+      "fontClass": "ms-fontColor-gray110",
+      "bgClass": "ms-bgColor-gray110",
+      "borderClass": "ms-borderColor-gray110"
+    },
+    {
+      "name": "Gray100",
+      "hex": "#979593",
+      "fontClass": "ms-fontColor-gray100",
+      "bgClass": "ms-bgColor-gray100",
+      "borderClass": "ms-borderColor-gray100"
+    },
+    {
+      "name": "Gray90",
+      "hex": "#a19f9d",
+      "fontClass": "ms-fontColor-gray90",
+      "bgClass": "ms-bgColor-gray90",
+      "borderClass": "ms-borderColor-gray90"
+    },
+    {
+      "name": "Gray80",
+      "hex": "#b3b0ad",
+      "fontClass": "ms-fontColor-gray80",
+      "bgClass": "ms-bgColor-gray80",
+      "borderClass": "ms-borderColor-gray80"
+    },
+    {
+      "name": "Gray70",
+      "hex": "#bebbb8",
+      "fontClass": "ms-fontColor-gray70",
+      "bgClass": "ms-bgColor-gray70",
+      "borderClass": "ms-borderColor-gray70",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "Gray60",
+      "hex": "#c8c6c4",
+      "fontClass": "ms-fontColor-gray60",
+      "bgClass": "ms-bgColor-gray60",
+      "borderClass": "ms-borderColor-gray60",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "Gray50",
+      "hex": "#d2d0ce",
+      "fontClass": "ms-fontColor-gray50",
+      "bgClass": "ms-bgColor-gray50",
+      "borderClass": "ms-borderColor-gray50",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "Gray40",
+      "hex": "#e1dfdd",
+      "fontClass": "ms-fontColor-gray40",
+      "bgClass": "ms-bgColor-gray40",
+      "borderClass": "ms-borderColor-gray40",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "Gray30",
+      "hex": "#edebe9",
+      "fontClass": "ms-fontColor-gray30",
+      "bgClass": "ms-bgColor-gray30",
+      "borderClass": "ms-borderColor-gray30",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "Gray20",
+      "hex": "#f3f2f1",
+      "fontClass": "ms-fontColor-gray20",
+      "bgClass": "ms-bgColor-gray20",
+      "borderClass": "ms-borderColor-gray20",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "Gray10",
+      "hex": "#faf9f8",
+      "fontClass": "ms-fontColor-gray10",
+      "bgClass": "ms-bgColor-gray10",
+      "borderClass": "ms-borderColor-gray10",
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
+    },
+    {
+      "name": "white",
+      "hex": "#ffffff",
       "fontClass": "ms-fontColor-white",
       "bgClass": "ms-bgColor-white",
       "borderClass": "ms-borderColor-white",
-      "secondBgClass": "ms-bgColor-neutralPrimary"
+      "secondBgClass": "ms-bgColor-neutralPrimary",
+      "customNameColor": "ms-fontColor-black"
     }
   ]
 }

--- a/src/documentation/templates/models/NeutralColorsModel.json
+++ b/src/documentation/templates/models/NeutralColorsModel.json
@@ -33,7 +33,8 @@
       "hex": "#201f1e",
       "fontClass": "ms-fontColor-gray190",
       "bgClass": "ms-bgColor-gray190",
-      "borderClass": "ms-borderColor-gray190"
+      "borderClass": "ms-borderColor-gray190",
+      "mdl2Equivalent": "neutralDark"
     },
     {
       "name": "Gray180",
@@ -54,14 +55,16 @@
       "hex": "#323130",
       "fontClass": "ms-fontColor-gray160",
       "bgClass": "ms-bgColor-gray160",
-      "borderClass": "ms-borderColor-gray160"
+      "borderClass": "ms-borderColor-gray160",
+      "mdl2Equivalent": "neutralPrimary"
     },
     {
       "name": "Gray150",
       "hex": "#3b3a39",
       "fontClass": "ms-fontColor-gray150",
       "bgClass": "ms-bgColor-gray150",
-      "borderClass": "ms-borderColor-gray150"
+      "borderClass": "ms-borderColor-gray150",
+      "mdl2Equivalent": "neutralPrimaryAlt"
     },
     {
       "name": "Gray140",
@@ -75,14 +78,16 @@
       "hex": "#605e5c",
       "fontClass": "ms-fontColor-gray130",
       "bgClass": "ms-bgColor-gray130",
-      "borderClass": "ms-borderColor-gray130"
+      "borderClass": "ms-borderColor-gray130",
+      "mdl2Equivalent": "neutralSecondary"
     },
     {
       "name": "Gray120",
       "hex": "#797775",
       "fontClass": "ms-fontColor-gray120",
       "bgClass": "ms-bgColor-gray120",
-      "borderClass": "ms-borderColor-gray120"
+      "borderClass": "ms-borderColor-gray120",
+      "mdl2Equivalent": "neutralSecondaryAlt"
     },
     {
       "name": "Gray110",
@@ -103,7 +108,8 @@
       "hex": "#a19f9d",
       "fontClass": "ms-fontColor-gray90",
       "bgClass": "ms-bgColor-gray90",
-      "borderClass": "ms-borderColor-gray90"
+      "borderClass": "ms-borderColor-gray90",
+      "mdl2Equivalent": "neutralTertiary"
     },
     {
       "name": "Gray80",
@@ -128,7 +134,8 @@
       "bgClass": "ms-bgColor-gray60",
       "borderClass": "ms-borderColor-gray60",
       "secondBgClass": "ms-bgColor-neutralPrimary",
-      "customNameColor": "ms-fontColor-black"
+      "customNameColor": "ms-fontColor-black",
+      "mdl2Equivalent": "neutralTertiaryAlt"
     },
     {
       "name": "Gray50",
@@ -137,7 +144,8 @@
       "bgClass": "ms-bgColor-gray50",
       "borderClass": "ms-borderColor-gray50",
       "secondBgClass": "ms-bgColor-neutralPrimary",
-      "customNameColor": "ms-fontColor-black"
+      "customNameColor": "ms-fontColor-black",
+      "mdl2Equivalent": "neutralQuaternary"
     },
     {
       "name": "Gray40",
@@ -146,7 +154,8 @@
       "bgClass": "ms-bgColor-gray40",
       "borderClass": "ms-borderColor-gray40",
       "secondBgClass": "ms-bgColor-neutralPrimary",
-      "customNameColor": "ms-fontColor-black"
+      "customNameColor": "ms-fontColor-black",
+      "mdl2Equivalent": "neutralQuaternaryAlt"
     },
     {
       "name": "Gray30",
@@ -155,7 +164,8 @@
       "bgClass": "ms-bgColor-gray30",
       "borderClass": "ms-borderColor-gray30",
       "secondBgClass": "ms-bgColor-neutralPrimary",
-      "customNameColor": "ms-fontColor-black"
+      "customNameColor": "ms-fontColor-black",
+      "mdl2Equivalent": "neutralLight"
     },
     {
       "name": "Gray20",
@@ -164,7 +174,8 @@
       "bgClass": "ms-bgColor-gray20",
       "borderClass": "ms-borderColor-gray20",
       "secondBgClass": "ms-bgColor-neutralPrimary",
-      "customNameColor": "ms-fontColor-black"
+      "customNameColor": "ms-fontColor-black",
+      "mdl2Equivalent": "neutralLighter"
     },
     {
       "name": "Gray10",
@@ -173,7 +184,8 @@
       "bgClass": "ms-bgColor-gray10",
       "borderClass": "ms-borderColor-gray10",
       "secondBgClass": "ms-bgColor-neutralPrimary",
-      "customNameColor": "ms-fontColor-black"
+      "customNameColor": "ms-fontColor-black",
+      "mdl2Equivalent": "neutralLighterAlt"
     },
     {
       "name": "white",

--- a/src/sass/_Color.MDL2.scss
+++ b/src/sass/_Color.MDL2.scss
@@ -1,0 +1,506 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+//
+// Office UI Fabric
+// --------------------------------------------------
+// Fabric Core Color Mixins
+
+//== Background colors
+//
+// Theme colors
+.ms-bgColor-themeDark,
+.ms-bgColor-themeDark--hover:hover {
+  @include ms-bgColor-themeDark;
+}
+
+.ms-bgColor-themeDarkAlt,
+.ms-bgColor-themeDarkAlt--hover:hover {
+  @include ms-bgColor-themeDarkAlt;
+}
+
+.ms-bgColor-themeDarker,
+.ms-bgColor-themeDarker--hover:hover {
+  @include ms-bgColor-themeDarker;
+}
+
+.ms-bgColor-themePrimary,
+.ms-bgColor-themePrimary--hover:hover {
+  @include ms-bgColor-themePrimary;
+}
+
+.ms-bgColor-themeSecondary,
+.ms-bgColor-themeSecondary--hover:hover {
+  @include ms-bgColor-themeSecondary;
+}
+
+.ms-bgColor-themeTertiary,
+.ms-bgColor-themeTertiary--hover:hover {
+  @include ms-bgColor-themeTertiary;
+}
+
+.ms-bgColor-themeLight,
+.ms-bgColor-themeLight--hover:hover {
+  @include ms-bgColor-themeLight;
+}
+
+.ms-bgColor-themeLighter,
+.ms-bgColor-themeLighter--hover:hover {
+  @include ms-bgColor-themeLighter;
+}
+
+.ms-bgColor-themeLighterAlt,
+.ms-bgColor-themeLighterAlt--hover:hover {
+  @include ms-bgColor-themeLighterAlt;
+}
+
+// Neutral colors
+.ms-bgColor-black,
+.ms-bgColor-black--hover:hover {
+  @include ms-bgColor-black;
+}
+
+.ms-bgColor-neutralDark,
+.ms-bgColor-neutralDark--hover:hover {
+  @include ms-bgColor-neutralDark;
+}
+
+.ms-bgColor-neutralPrimary,
+.ms-bgColor-neutralPrimary--hover:hover {
+  @include ms-bgColor-neutralPrimary;
+}
+
+.ms-bgColor-neutralPrimaryAlt, 
+.ms-bgColor-neutralPrimaryAlt--hover:hover {
+  @include ms-bgColor-neutralPrimaryAlt;
+}
+
+.ms-bgColor-neutralSecondary, 
+.ms-bgColor-neutralSecondary--hover:hover {
+  @include ms-bgColor-neutralSecondary;
+}
+
+.ms-bgColor-neutralSecondaryAlt,
+.ms-bgColor-neutralSecondaryAlt--hover:hover {
+  @include ms-bgColor-neutralSecondaryAlt;
+}
+
+.ms-bgColor-neutralTertiary,
+.ms-bgColor-neutralTertiary--hover:hover {
+  @include ms-bgColor-neutralTertiary;
+}
+
+.ms-bgColor-neutralTertiaryAlt,
+.ms-bgColor-neutralTertiaryAlt--hover:hover {
+  @include ms-bgColor-neutralTertiaryAlt;
+}
+
+.ms-bgColor-neutralQuaternary,
+.ms-bgColor-neutralQuaternary--hover:hover {
+  @include ms-bgColor-neutralQuaternary;
+}
+
+.ms-bgColor-neutralQuaternaryAlt,
+.ms-bgColor-neutralQuaternaryAlt--hover:hover {
+  @include ms-bgColor-neutralQuaternaryAlt;
+}
+
+.ms-bgColor-neutralLight,
+.ms-bgColor-neutralLight--hover:hover {
+  @include ms-bgColor-neutralLight;
+}
+
+.ms-bgColor-neutralLighter,
+.ms-bgColor-neutralLighter--hover:hover {
+  @include ms-bgColor-neutralLighter;
+}
+
+.ms-bgColor-neutralLighterAlt,
+.ms-bgColor-neutralLighterAlt--hover:hover {
+  @include ms-bgColor-neutralLighterAlt;
+}
+
+.ms-bgColor-white,
+.ms-bgColor-white--hover:hover {
+  @include ms-bgColor-white;
+}
+
+
+// Brand and accent colors
+.ms-bgColor-yellow,
+.ms-bgColor-yellow--hover:hover {
+  @include ms-bgColor-yellow;
+}
+
+.ms-bgColor-yellowLight,
+.ms-bgColor-yellowLight--hover:hover {
+  @include ms-bgColor-yellowLight;
+}
+
+.ms-bgColor-orange,
+.ms-bgColor-orange--hover:hover {
+  @include ms-bgColor-orange;
+}
+
+.ms-bgColor-orangeLight,
+.ms-bgColor-orangeLight--hover:hover {
+  @include ms-bgColor-orangeLight;
+}
+
+.ms-bgColor-orangeLighter,
+.ms-bgColor-orangeLighter--hover:hover {
+  @include ms-bgColor-orangeLighter;
+}
+
+.ms-bgColor-redDark,
+.ms-bgColor-redDark--hover:hover {
+  @include ms-bgColor-redDark;
+}
+
+.ms-bgColor-red,
+.ms-bgColor-red--hover:hover {
+  @include ms-bgColor-red;
+}
+
+.ms-bgColor-magentaDark,
+.ms-bgColor-magentaDark--hover:hover {
+  @include ms-bgColor-magentaDark;
+}
+
+.ms-bgColor-magenta,
+.ms-bgColor-magenta--hover:hover {
+  @include ms-bgColor-magenta;
+}
+
+.ms-bgColor-magentaLight,
+.ms-bgColor-magentaLight--hover:hover {
+  @include ms-bgColor-magentaLight;
+}
+
+.ms-bgColor-purpleDark,
+.ms-bgColor-purpleDark--hover:hover {
+  @include ms-bgColor-purpleDark;
+}
+
+.ms-bgColor-purple,
+.ms-bgColor-purple--hover:hover {
+  @include ms-bgColor-purple;
+}
+
+.ms-bgColor-purpleLight,
+.ms-bgColor-purpleLight--hover:hover {
+  @include ms-bgColor-purpleLight;
+}
+
+.ms-bgColor-blueDark,
+.ms-bgColor-blueDark--hover:hover {
+  @include ms-bgColor-blueDark;
+}
+
+.ms-bgColor-blueMid,
+.ms-bgColor-blueMid--hover:hover {
+  @include ms-bgColor-blueMid;
+}
+
+.ms-bgColor-blue,
+.ms-bgColor-blue--hover:hover {
+  @include ms-bgColor-blue;
+}
+
+.ms-bgColor-blueLight,
+.ms-bgColor-blueLight--hover:hover {
+  @include ms-bgColor-blueLight;
+}
+
+.ms-bgColor-tealDark,
+.ms-bgColor-tealDark--hover:hover {
+  @include ms-bgColor-tealDark;
+}
+
+.ms-bgColor-teal,
+.ms-bgColor-teal--hover:hover {
+  @include ms-bgColor-teal;
+}
+
+.ms-bgColor-tealLight,
+.ms-bgColor-tealLight--hover:hover {
+  @include ms-bgColor-tealLight;
+}
+
+.ms-bgColor-greenDark,
+.ms-bgColor-greenDark--hover:hover {
+  @include ms-bgColor-greenDark;
+}
+
+.ms-bgColor-green,
+.ms-bgColor-green--hover:hover {
+  @include ms-bgColor-green;
+}
+
+.ms-bgColor-greenLight,
+.ms-bgColor-greenLight--hover:hover {
+  @include ms-bgColor-greenLight;
+}
+
+// Message colors
+.ms-bgColor-info,
+.ms-bgColor-info--hover:hover {
+  @include ms-bgColor-info;
+}
+
+.ms-bgColor-success,
+.ms-bgColor-success--hover:hover {
+  @include ms-bgColor-success;
+}
+
+.ms-bgColor-severeWarning,
+.ms-bgColor-severeWarning--hover:hover {
+  @include ms-bgColor-severeWarning;
+}
+
+.ms-bgColor-warning,
+.ms-bgColor-warning--hover:hover {
+  @include ms-bgColor-warning;
+}
+
+.ms-bgColor-error,
+.ms-bgColor-error--hover:hover {
+  @include ms-bgColor-error;
+}
+
+
+//== Border colors
+//
+
+// Theme colors
+.ms-borderColor-themeDark,
+.ms-borderColor-themeDark--hover:hover {
+  @include ms-borderColor-themeDark;
+}
+
+.ms-borderColor-themeDarkAlt,
+.ms-borderColor-themeDarkAlt--hover:hover {
+  @include ms-borderColor-themeDarkAlt;
+}
+
+.ms-borderColor-themeDarker,
+.ms-borderColor-themeDarker--hover:hover {
+  @include ms-borderColor-themeDarker;
+}
+
+.ms-borderColor-themePrimary,
+.ms-borderColor-themePrimary--hover:hover {
+  @include ms-borderColor-themePrimary;
+}
+
+.ms-borderColor-themeSecondary,
+.ms-borderColor-themeSecondary--hover:hover {
+  @include ms-borderColor-themeSecondary;
+}
+
+.ms-borderColor-themeTertiary,
+.ms-borderColor-themeTertiary--hover:hover {
+  @include ms-borderColor-themeTertiary;
+}
+
+.ms-borderColor-themeLight,
+.ms-borderColor-themeLight--hover:hover {
+  @include ms-borderColor-themeLight;
+}
+
+.ms-borderColor-themeLighter,
+.ms-borderColor-themeLighter--hover:hover {
+  @include ms-borderColor-themeLighter;
+}
+
+.ms-borderColor-themeLighterAlt,
+.ms-borderColor-themeLighterAlt--hover:hover {
+  @include ms-borderColor-themeLighterAlt;
+}
+
+
+// Neutral colors
+.ms-borderColor-black,
+.ms-borderColor-black--hover:hover {
+  @include ms-borderColor-black;
+}
+
+.ms-borderColor-neutralDark,
+.ms-borderColor-neutralDark--hover:hover {
+  @include ms-borderColor-neutralDark;
+}
+
+.ms-borderColor-neutralPrimary,
+.ms-borderColor-neutralPrimary--hover:hover {
+  @include ms-borderColor-neutralPrimary;
+}
+
+.ms-borderColor-neutralPrimaryAlt, 
+.ms-borderColor-neutralPrimaryAlt--hover:hover {
+  @include ms-borderColor-neutralPrimaryAlt;
+}
+
+.ms-borderColor-neutralSecondary, 
+.ms-borderColor-neutralSecondary--hover:hover {
+  @include ms-borderColor-neutralSecondary;
+}
+
+.ms-borderColor-neutralSecondaryAlt,
+.ms-borderColor-neutralSecondaryAlt--hover:hover {
+  @include ms-borderColor-neutralSecondaryAlt;
+}
+
+.ms-borderColor-neutralTertiary,
+.ms-borderColor-neutralTertiary--hover:hover {
+  @include ms-borderColor-neutralTertiary;
+}
+
+.ms-borderColor-neutralTertiaryAlt,
+.ms-borderColor-neutralTertiaryAlt--hover:hover {
+  @include ms-borderColor-neutralTertiaryAlt;
+}
+
+.ms-borderColor-neutralQuaternary,
+.ms-borderColor-neutralQuaternary--hover:hover {
+  @include ms-borderColor-neutralQuaternary;
+}
+
+.ms-borderColor-neutralQuaternaryAlt,
+.ms-borderColor-neutralQuaternaryAlt--hover:hover {
+  @include ms-borderColor-neutralQuaternaryAlt;
+}
+
+.ms-borderColor-neutralLight,
+.ms-borderColor-neutralLight--hover:hover {
+  @include ms-borderColor-neutralLight;
+}
+
+.ms-borderColor-neutralLighter,
+.ms-borderColor-neutralLighter--hover:hover {
+  @include ms-borderColor-neutralLighter;
+}
+
+.ms-borderColor-neutralLighterAlt,
+.ms-borderColor-neutralLighterAlt--hover:hover {
+  @include ms-borderColor-neutralLighterAlt;
+}
+
+.ms-borderColor-white,
+.ms-borderColor-white--hover:hover {
+  @include ms-borderColor-white;
+}
+
+// Brand and accent colors
+.ms-borderColor-yellow,
+.ms-borderColor-yellow--hover:hover {
+  @include ms-borderColor-yellow;
+}
+
+.ms-borderColor-yellowLight,
+.ms-borderColor-yellowLight--hover:hover {
+  @include ms-borderColor-yellowLight;
+}
+
+.ms-borderColor-orange,
+.ms-borderColor-orange--hover:hover {
+  @include ms-borderColor-orange;
+}
+
+.ms-borderColor-orangeLight,
+.ms-borderColor-orangeLight--hover:hover {
+  @include ms-borderColor-orangeLight;
+}
+
+.ms-borderColor-orangeLighter,
+.ms-borderColor-orangeLighter--hover:hover {
+  @include ms-borderColor-orangeLighter;
+}
+
+.ms-borderColor-redDark,
+.ms-borderColor-redDark--hover:hover {
+  @include ms-borderColor-redDark;
+}
+
+.ms-borderColor-red,
+.ms-borderColor-red--hover:hover {
+  @include ms-borderColor-red;
+}
+
+.ms-borderColor-magentaDark,
+.ms-borderColor-magentaDark--hover:hover {
+  @include ms-borderColor-magentaDark;
+}
+
+.ms-borderColor-magenta,
+.ms-borderColor-magenta--hover:hover {
+  @include ms-borderColor-magenta;
+}
+
+.ms-borderColor-magentaLight,
+.ms-borderColor-magentaLight--hover:hover {
+  @include ms-borderColor-magentaLight;
+}
+
+.ms-borderColor-purpleDark,
+.ms-borderColor-purpleDark--hover:hover {
+  @include ms-borderColor-purpleDark;
+}
+
+.ms-borderColor-purple,
+.ms-borderColor-purple--hover:hover {
+  @include ms-borderColor-purple;
+}
+
+.ms-borderColor-purpleLight,
+.ms-borderColor-purpleLight--hover:hover {
+  @include ms-borderColor-purpleLight;
+}
+
+.ms-borderColor-blueDark,
+.ms-borderColor-blueDark--hover:hover {
+  @include ms-borderColor-blueDark;
+}
+
+.ms-borderColor-blueMid,
+.ms-borderColor-blueMid--hover:hover {
+  @include ms-borderColor-blueMid;
+}
+
+.ms-borderColor-blue,
+.ms-borderColor-blue--hover:hover {
+  @include ms-borderColor-blue;
+}
+
+.ms-borderColor-blueLight,
+.ms-borderColor-blueLight--hover:hover {
+  @include ms-borderColor-blueLight;
+}
+
+.ms-borderColor-tealDark,
+.ms-borderColor-tealDark--hover:hover {
+  @include ms-borderColor-tealDark;
+}
+
+.ms-borderColor-teal,
+.ms-borderColor-teal--hover:hover {
+  @include ms-borderColor-teal;
+}
+
+.ms-borderColor-tealLight,
+.ms-borderColor-tealLight--hover:hover {
+  @include ms-borderColor-tealLight;
+}
+
+.ms-borderColor-greenDark,
+.ms-borderColor-greenDark--hover:hover {
+  @include ms-borderColor-greenDark;
+}
+
+.ms-borderColor-green,
+.ms-borderColor-green--hover:hover {
+  @include ms-borderColor-green;
+}
+
+.ms-borderColor-greenLight,
+.ms-borderColor-greenLight--hover:hover {
+  @include ms-borderColor-greenLight;
+}

--- a/src/sass/_Color.scss
+++ b/src/sass/_Color.scss
@@ -1,506 +1,206 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
+// Deprecated MDL2 color classes.
+@import "./Color.MDL2";
+
+//== Background color classes.
 //
-// Office UI Fabric
-// --------------------------------------------------
-// Fabric Core Color Mixins
 
-//== Background colors
-//
-// Theme colors
-.ms-bgColor-themeDark,
-.ms-bgColor-themeDark--hover:hover {
-  @include ms-bgColor-themeDark;
-}
-
-.ms-bgColor-themeDarkAlt,
-.ms-bgColor-themeDarkAlt--hover:hover {
-  @include ms-bgColor-themeDarkAlt;
-}
-
-.ms-bgColor-themeDarker,
-.ms-bgColor-themeDarker--hover:hover {
-  @include ms-bgColor-themeDarker;
-}
-
-.ms-bgColor-themePrimary,
-.ms-bgColor-themePrimary--hover:hover {
-  @include ms-bgColor-themePrimary;
-}
-
-.ms-bgColor-themeSecondary,
-.ms-bgColor-themeSecondary--hover:hover {
-  @include ms-bgColor-themeSecondary;
-}
-
-.ms-bgColor-themeTertiary,
-.ms-bgColor-themeTertiary--hover:hover {
-  @include ms-bgColor-themeTertiary;
-}
-
-.ms-bgColor-themeLight,
-.ms-bgColor-themeLight--hover:hover {
-  @include ms-bgColor-themeLight;
-}
-
-.ms-bgColor-themeLighter,
-.ms-bgColor-themeLighter--hover:hover {
-  @include ms-bgColor-themeLighter;
-}
-
-.ms-bgColor-themeLighterAlt,
-.ms-bgColor-themeLighterAlt--hover:hover {
-  @include ms-bgColor-themeLighterAlt;
-}
-
-// Neutral colors
+// Grays.
 .ms-bgColor-black,
 .ms-bgColor-black--hover:hover {
   @include ms-bgColor-black;
 }
-
-.ms-bgColor-neutralDark,
-.ms-bgColor-neutralDark--hover:hover {
-  @include ms-bgColor-neutralDark;
+.ms-bgColor-gray220,
+.ms-bgColor-gray220--hover:hover {
+  @include ms-bgColor-gray220;
 }
-
-.ms-bgColor-neutralPrimary,
-.ms-bgColor-neutralPrimary--hover:hover {
-  @include ms-bgColor-neutralPrimary;
+.ms-bgColor-gray210,
+.ms-bgColor-gray210--hover:hover {
+  @include ms-bgColor-gray210;
 }
-
-.ms-bgColor-neutralPrimaryAlt, 
-.ms-bgColor-neutralPrimaryAlt--hover:hover {
-  @include ms-bgColor-neutralPrimaryAlt;
+.ms-bgColor-gray200,
+.ms-bgColor-gray200--hover:hover {
+  @include ms-bgColor-gray200;
 }
-
-.ms-bgColor-neutralSecondary, 
-.ms-bgColor-neutralSecondary--hover:hover {
-  @include ms-bgColor-neutralSecondary;
+.ms-bgColor-gray190,
+.ms-bgColor-gray190--hover:hover {
+  @include ms-bgColor-gray190;
 }
-
-.ms-bgColor-neutralSecondaryAlt,
-.ms-bgColor-neutralSecondaryAlt--hover:hover {
-  @include ms-bgColor-neutralSecondaryAlt;
+.ms-bgColor-gray180,
+.ms-bgColor-gray180--hover:hover {
+  @include ms-bgColor-gray180;
 }
-
-.ms-bgColor-neutralTertiary,
-.ms-bgColor-neutralTertiary--hover:hover {
-  @include ms-bgColor-neutralTertiary;
+.ms-bgColor-gray170,
+.ms-bgColor-gray170--hover:hover {
+  @include ms-bgColor-gray170;
 }
-
-.ms-bgColor-neutralTertiaryAlt,
-.ms-bgColor-neutralTertiaryAlt--hover:hover {
-  @include ms-bgColor-neutralTertiaryAlt;
+.ms-bgColor-gray160,
+.ms-bgColor-gray160--hover:hover {
+  @include ms-bgColor-gray160;
 }
-
-.ms-bgColor-neutralQuaternary,
-.ms-bgColor-neutralQuaternary--hover:hover {
-  @include ms-bgColor-neutralQuaternary;
+.ms-bgColor-gray150,
+.ms-bgColor-gray150--hover:hover {
+  @include ms-bgColor-gray150;
 }
-
-.ms-bgColor-neutralQuaternaryAlt,
-.ms-bgColor-neutralQuaternaryAlt--hover:hover {
-  @include ms-bgColor-neutralQuaternaryAlt;
+.ms-bgColor-gray140,
+.ms-bgColor-gray140--hover:hover {
+  @include ms-bgColor-gray140;
 }
-
-.ms-bgColor-neutralLight,
-.ms-bgColor-neutralLight--hover:hover {
-  @include ms-bgColor-neutralLight;
+.ms-bgColor-gray130,
+.ms-bgColor-gray130--hover:hover {
+  @include ms-bgColor-gray130;
 }
-
-.ms-bgColor-neutralLighter,
-.ms-bgColor-neutralLighter--hover:hover {
-  @include ms-bgColor-neutralLighter;
+.ms-bgColor-gray120,
+.ms-bgColor-gray120--hover:hover {
+  @include ms-bgColor-gray120;
 }
-
-.ms-bgColor-neutralLighterAlt,
-.ms-bgColor-neutralLighterAlt--hover:hover {
-  @include ms-bgColor-neutralLighterAlt;
+.ms-bgColor-gray110,
+.ms-bgColor-gray110--hover:hover {
+  @include ms-bgColor-gray110;
 }
-
+.ms-bgColor-gray100,
+.ms-bgColor-gray100--hover:hover {
+  @include ms-bgColor-gray100;
+}
+.ms-bgColor-gray90,
+.ms-bgColor-gray90--hover:hover {
+  @include ms-bgColor-gray90;
+}
+.ms-bgColor-gray80,
+.ms-bgColor-gray80--hover:hover {
+  @include ms-bgColor-gray80;
+}
+.ms-bgColor-gray70,
+.ms-bgColor-gray70--hover:hover {
+  @include ms-bgColor-gray70;
+}
+.ms-bgColor-gray60,
+.ms-bgColor-gray60--hover:hover {
+  @include ms-bgColor-gray60;
+}
+.ms-bgColor-gray50,
+.ms-bgColor-gray50--hover:hover {
+  @include ms-bgColor-gray50;
+}
+.ms-bgColor-gray40,
+.ms-bgColor-gray40--hover:hover {
+  @include ms-bgColor-gray40;
+}
+.ms-bgColor-gray30,
+.ms-bgColor-gray30--hover:hover {
+  @include ms-bgColor-gray30;
+}
+.ms-bgColor-gray20,
+.ms-bgColor-gray20--hover:hover {
+  @include ms-bgColor-gray20;
+}
+.ms-bgColor-gray10,
+.ms-bgColor-gray10--hover:hover {
+  @include ms-bgColor-gray10;
+}
 .ms-bgColor-white,
 .ms-bgColor-white--hover:hover {
   @include ms-bgColor-white;
 }
 
-
-// Brand and accent colors
-.ms-bgColor-yellow,
-.ms-bgColor-yellow--hover:hover {
-  @include ms-bgColor-yellow;
-}
-
-.ms-bgColor-yellowLight,
-.ms-bgColor-yellowLight--hover:hover {
-  @include ms-bgColor-yellowLight;
-}
-
-.ms-bgColor-orange,
-.ms-bgColor-orange--hover:hover {
-  @include ms-bgColor-orange;
-}
-
-.ms-bgColor-orangeLight,
-.ms-bgColor-orangeLight--hover:hover {
-  @include ms-bgColor-orangeLight;
-}
-
-.ms-bgColor-orangeLighter,
-.ms-bgColor-orangeLighter--hover:hover {
-  @include ms-bgColor-orangeLighter;
-}
-
-.ms-bgColor-redDark,
-.ms-bgColor-redDark--hover:hover {
-  @include ms-bgColor-redDark;
-}
-
-.ms-bgColor-red,
-.ms-bgColor-red--hover:hover {
-  @include ms-bgColor-red;
-}
-
-.ms-bgColor-magentaDark,
-.ms-bgColor-magentaDark--hover:hover {
-  @include ms-bgColor-magentaDark;
-}
-
-.ms-bgColor-magenta,
-.ms-bgColor-magenta--hover:hover {
-  @include ms-bgColor-magenta;
-}
-
-.ms-bgColor-magentaLight,
-.ms-bgColor-magentaLight--hover:hover {
-  @include ms-bgColor-magentaLight;
-}
-
-.ms-bgColor-purpleDark,
-.ms-bgColor-purpleDark--hover:hover {
-  @include ms-bgColor-purpleDark;
-}
-
-.ms-bgColor-purple,
-.ms-bgColor-purple--hover:hover {
-  @include ms-bgColor-purple;
-}
-
-.ms-bgColor-purpleLight,
-.ms-bgColor-purpleLight--hover:hover {
-  @include ms-bgColor-purpleLight;
-}
-
-.ms-bgColor-blueDark,
-.ms-bgColor-blueDark--hover:hover {
-  @include ms-bgColor-blueDark;
-}
-
-.ms-bgColor-blueMid,
-.ms-bgColor-blueMid--hover:hover {
-  @include ms-bgColor-blueMid;
-}
-
-.ms-bgColor-blue,
-.ms-bgColor-blue--hover:hover {
-  @include ms-bgColor-blue;
-}
-
-.ms-bgColor-blueLight,
-.ms-bgColor-blueLight--hover:hover {
-  @include ms-bgColor-blueLight;
-}
-
-.ms-bgColor-tealDark,
-.ms-bgColor-tealDark--hover:hover {
-  @include ms-bgColor-tealDark;
-}
-
-.ms-bgColor-teal,
-.ms-bgColor-teal--hover:hover {
-  @include ms-bgColor-teal;
-}
-
-.ms-bgColor-tealLight,
-.ms-bgColor-tealLight--hover:hover {
-  @include ms-bgColor-tealLight;
-}
-
-.ms-bgColor-greenDark,
-.ms-bgColor-greenDark--hover:hover {
-  @include ms-bgColor-greenDark;
-}
-
-.ms-bgColor-green,
-.ms-bgColor-green--hover:hover {
-  @include ms-bgColor-green;
-}
-
-.ms-bgColor-greenLight,
-.ms-bgColor-greenLight--hover:hover {
-  @include ms-bgColor-greenLight;
-}
-
-// Message colors
-.ms-bgColor-info,
-.ms-bgColor-info--hover:hover {
-  @include ms-bgColor-info;
-}
-
-.ms-bgColor-success,
-.ms-bgColor-success--hover:hover {
-  @include ms-bgColor-success;
-}
-
-.ms-bgColor-severeWarning,
-.ms-bgColor-severeWarning--hover:hover {
-  @include ms-bgColor-severeWarning;
-}
-
-.ms-bgColor-warning,
-.ms-bgColor-warning--hover:hover {
-  @include ms-bgColor-warning;
-}
-
-.ms-bgColor-error,
-.ms-bgColor-error--hover:hover {
-  @include ms-bgColor-error;
-}
-
-
-//== Border colors
+//== Border color classes.
 //
 
-// Theme colors
-.ms-borderColor-themeDark,
-.ms-borderColor-themeDark--hover:hover {
-  @include ms-borderColor-themeDark;
-}
-
-.ms-borderColor-themeDarkAlt,
-.ms-borderColor-themeDarkAlt--hover:hover {
-  @include ms-borderColor-themeDarkAlt;
-}
-
-.ms-borderColor-themeDarker,
-.ms-borderColor-themeDarker--hover:hover {
-  @include ms-borderColor-themeDarker;
-}
-
-.ms-borderColor-themePrimary,
-.ms-borderColor-themePrimary--hover:hover {
-  @include ms-borderColor-themePrimary;
-}
-
-.ms-borderColor-themeSecondary,
-.ms-borderColor-themeSecondary--hover:hover {
-  @include ms-borderColor-themeSecondary;
-}
-
-.ms-borderColor-themeTertiary,
-.ms-borderColor-themeTertiary--hover:hover {
-  @include ms-borderColor-themeTertiary;
-}
-
-.ms-borderColor-themeLight,
-.ms-borderColor-themeLight--hover:hover {
-  @include ms-borderColor-themeLight;
-}
-
-.ms-borderColor-themeLighter,
-.ms-borderColor-themeLighter--hover:hover {
-  @include ms-borderColor-themeLighter;
-}
-
-.ms-borderColor-themeLighterAlt,
-.ms-borderColor-themeLighterAlt--hover:hover {
-  @include ms-borderColor-themeLighterAlt;
-}
-
-
-// Neutral colors
+// Grays.
 .ms-borderColor-black,
 .ms-borderColor-black--hover:hover {
   @include ms-borderColor-black;
 }
-
-.ms-borderColor-neutralDark,
-.ms-borderColor-neutralDark--hover:hover {
-  @include ms-borderColor-neutralDark;
+.ms-borderColor-gray220,
+.ms-borderColor-gray220--hover:hover {
+  @include ms-borderColor-gray220;
 }
-
-.ms-borderColor-neutralPrimary,
-.ms-borderColor-neutralPrimary--hover:hover {
-  @include ms-borderColor-neutralPrimary;
+.ms-borderColor-gray210,
+.ms-borderColor-gray210--hover:hover {
+  @include ms-borderColor-gray210;
 }
-
-.ms-borderColor-neutralPrimaryAlt, 
-.ms-borderColor-neutralPrimaryAlt--hover:hover {
-  @include ms-borderColor-neutralPrimaryAlt;
+.ms-borderColor-gray200,
+.ms-borderColor-gray200--hover:hover {
+  @include ms-borderColor-gray200;
 }
-
-.ms-borderColor-neutralSecondary, 
-.ms-borderColor-neutralSecondary--hover:hover {
-  @include ms-borderColor-neutralSecondary;
+.ms-borderColor-gray190,
+.ms-borderColor-gray190--hover:hover {
+  @include ms-borderColor-gray190;
 }
-
-.ms-borderColor-neutralSecondaryAlt,
-.ms-borderColor-neutralSecondaryAlt--hover:hover {
-  @include ms-borderColor-neutralSecondaryAlt;
+.ms-borderColor-gray180,
+.ms-borderColor-gray180--hover:hover {
+  @include ms-borderColor-gray180;
 }
-
-.ms-borderColor-neutralTertiary,
-.ms-borderColor-neutralTertiary--hover:hover {
-  @include ms-borderColor-neutralTertiary;
+.ms-borderColor-gray170,
+.ms-borderColor-gray170--hover:hover {
+  @include ms-borderColor-gray170;
 }
-
-.ms-borderColor-neutralTertiaryAlt,
-.ms-borderColor-neutralTertiaryAlt--hover:hover {
-  @include ms-borderColor-neutralTertiaryAlt;
+.ms-borderColor-gray160,
+.ms-borderColor-gray160--hover:hover {
+  @include ms-borderColor-gray160;
 }
-
-.ms-borderColor-neutralQuaternary,
-.ms-borderColor-neutralQuaternary--hover:hover {
-  @include ms-borderColor-neutralQuaternary;
+.ms-borderColor-gray150,
+.ms-borderColor-gray150--hover:hover {
+  @include ms-borderColor-gray150;
 }
-
-.ms-borderColor-neutralQuaternaryAlt,
-.ms-borderColor-neutralQuaternaryAlt--hover:hover {
-  @include ms-borderColor-neutralQuaternaryAlt;
+.ms-borderColor-gray140,
+.ms-borderColor-gray140--hover:hover {
+  @include ms-borderColor-gray140;
 }
-
-.ms-borderColor-neutralLight,
-.ms-borderColor-neutralLight--hover:hover {
-  @include ms-borderColor-neutralLight;
+.ms-borderColor-gray130,
+.ms-borderColor-gray130--hover:hover {
+  @include ms-borderColor-gray130;
 }
-
-.ms-borderColor-neutralLighter,
-.ms-borderColor-neutralLighter--hover:hover {
-  @include ms-borderColor-neutralLighter;
+.ms-borderColor-gray120,
+.ms-borderColor-gray120--hover:hover {
+  @include ms-borderColor-gray120;
 }
-
-.ms-borderColor-neutralLighterAlt,
-.ms-borderColor-neutralLighterAlt--hover:hover {
-  @include ms-borderColor-neutralLighterAlt;
+.ms-borderColor-gray110,
+.ms-borderColor-gray110--hover:hover {
+  @include ms-borderColor-gray110;
 }
-
+.ms-borderColor-gray100,
+.ms-borderColor-gray100--hover:hover {
+  @include ms-borderColor-gray100;
+}
+.ms-borderColor-gray90,
+.ms-borderColor-gray90--hover:hover {
+  @include ms-borderColor-gray90;
+}
+.ms-borderColor-gray80,
+.ms-borderColor-gray80--hover:hover {
+  @include ms-borderColor-gray80;
+}
+.ms-borderColor-gray70,
+.ms-borderColor-gray70--hover:hover {
+  @include ms-borderColor-gray70;
+}
+.ms-borderColor-gray60,
+.ms-borderColor-gray60--hover:hover {
+  @include ms-borderColor-gray60;
+}
+.ms-borderColor-gray50,
+.ms-borderColor-gray50--hover:hover {
+  @include ms-borderColor-gray50;
+}
+.ms-borderColor-gray40,
+.ms-borderColor-gray40--hover:hover {
+  @include ms-borderColor-gray40;
+}
+.ms-borderColor-gray30,
+.ms-borderColor-gray30--hover:hover {
+  @include ms-borderColor-gray30;
+}
+.ms-borderColor-gray20,
+.ms-borderColor-gray20--hover:hover {
+  @include ms-borderColor-gray20;
+}
+.ms-borderColor-gray10,
+.ms-borderColor-gray10--hover:hover {
+  @include ms-borderColor-gray10;
+}
 .ms-borderColor-white,
 .ms-borderColor-white--hover:hover {
   @include ms-borderColor-white;
-}
-
-// Brand and accent colors
-.ms-borderColor-yellow,
-.ms-borderColor-yellow--hover:hover {
-  @include ms-borderColor-yellow;
-}
-
-.ms-borderColor-yellowLight,
-.ms-borderColor-yellowLight--hover:hover {
-  @include ms-borderColor-yellowLight;
-}
-
-.ms-borderColor-orange,
-.ms-borderColor-orange--hover:hover {
-  @include ms-borderColor-orange;
-}
-
-.ms-borderColor-orangeLight,
-.ms-borderColor-orangeLight--hover:hover {
-  @include ms-borderColor-orangeLight;
-}
-
-.ms-borderColor-orangeLighter,
-.ms-borderColor-orangeLighter--hover:hover {
-  @include ms-borderColor-orangeLighter;
-}
-
-.ms-borderColor-redDark,
-.ms-borderColor-redDark--hover:hover {
-  @include ms-borderColor-redDark;
-}
-
-.ms-borderColor-red,
-.ms-borderColor-red--hover:hover {
-  @include ms-borderColor-red;
-}
-
-.ms-borderColor-magentaDark,
-.ms-borderColor-magentaDark--hover:hover {
-  @include ms-borderColor-magentaDark;
-}
-
-.ms-borderColor-magenta,
-.ms-borderColor-magenta--hover:hover {
-  @include ms-borderColor-magenta;
-}
-
-.ms-borderColor-magentaLight,
-.ms-borderColor-magentaLight--hover:hover {
-  @include ms-borderColor-magentaLight;
-}
-
-.ms-borderColor-purpleDark,
-.ms-borderColor-purpleDark--hover:hover {
-  @include ms-borderColor-purpleDark;
-}
-
-.ms-borderColor-purple,
-.ms-borderColor-purple--hover:hover {
-  @include ms-borderColor-purple;
-}
-
-.ms-borderColor-purpleLight,
-.ms-borderColor-purpleLight--hover:hover {
-  @include ms-borderColor-purpleLight;
-}
-
-.ms-borderColor-blueDark,
-.ms-borderColor-blueDark--hover:hover {
-  @include ms-borderColor-blueDark;
-}
-
-.ms-borderColor-blueMid,
-.ms-borderColor-blueMid--hover:hover {
-  @include ms-borderColor-blueMid;
-}
-
-.ms-borderColor-blue,
-.ms-borderColor-blue--hover:hover {
-  @include ms-borderColor-blue;
-}
-
-.ms-borderColor-blueLight,
-.ms-borderColor-blueLight--hover:hover {
-  @include ms-borderColor-blueLight;
-}
-
-.ms-borderColor-tealDark,
-.ms-borderColor-tealDark--hover:hover {
-  @include ms-borderColor-tealDark;
-}
-
-.ms-borderColor-teal,
-.ms-borderColor-teal--hover:hover {
-  @include ms-borderColor-teal;
-}
-
-.ms-borderColor-tealLight,
-.ms-borderColor-tealLight--hover:hover {
-  @include ms-borderColor-tealLight;
-}
-
-.ms-borderColor-greenDark,
-.ms-borderColor-greenDark--hover:hover {
-  @include ms-borderColor-greenDark;
-}
-
-.ms-borderColor-green,
-.ms-borderColor-green--hover:hover {
-  @include ms-borderColor-green;
-}
-
-.ms-borderColor-greenLight,
-.ms-borderColor-greenLight--hover:hover {
-  @include ms-borderColor-greenLight;
 }

--- a/src/sass/_Font.MDL2.scss
+++ b/src/sass/_Font.MDL2.scss
@@ -1,0 +1,407 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+//
+// Office UI Fabric
+// --------------------------------------------------
+
+// Super Styles (LIMITED USE)
+// Weights: Light
+.ms-font-su {
+  @include ms-font-su;
+}
+// No touch class for Super
+
+// Extra-Extra-Large
+// Allowed weights: Light, SemiLight
+.ms-font-xxl {
+  @include ms-font-xxl;
+}
+
+// Extra-Large Plus Styles
+// Allowed weights: Light, SemiLight
+.ms-font-xl-plus {
+  @include ms-font-xl-plus;
+}
+
+// Extra-Large Styles
+// Allowed weights: Light, SemiLight
+.ms-font-xl {
+  @include ms-font-xl;
+}
+
+// Large Styles
+// Allowed weights: SemiLight, Regular, Semibold
+.ms-font-l {
+  @include ms-font-l;
+}
+
+// Medium Plus Styles
+// Allowed weights: SemiLight, Regular, Semibold
+.ms-font-m-plus {
+  @include ms-font-m-plus;
+}
+
+// Medium Styles
+// Allowed weights: SemiLight, Regular, Semibold
+.ms-font-m {
+  @include ms-font-m;
+}
+
+// Small Plus Styles
+// Allowed weights: SemiLight, Regular, Semibold
+.ms-font-s-plus {
+  @include ms-font-s-plus;
+}
+
+// Small Styles
+// Allowed weights: SemiLight, Regular, Semibold
+.ms-font-s {
+  @include ms-font-s;
+}
+
+// XS Styles
+// Allowed weights: SemiLight, Regular, Semibold
+.ms-font-xs {
+  @include ms-font-xs;
+}
+
+// Micro Styles (LIMITED USE)
+// Weights: Semibold
+.ms-font-mi {
+  @include ms-font-mi;
+}
+
+//== Helper classes & mixins
+//
+// Helper mixins to override default type values
+
+// Font weights
+.ms-fontWeight-light {
+  @include ms-fontWeight-light;
+}
+
+.ms-fontWeight-semilight {
+  @include ms-fontWeight-semilight;
+}
+
+.ms-fontWeight-regular {
+  @include ms-fontWeight-regular;
+}
+
+.ms-fontWeight-semibold {
+  @include ms-fontWeight-semibold;
+}
+
+.ms-fontWeight-bold {
+  @include ms-fontWeight-bold;
+}
+
+// Font sizes
+.ms-fontSize-su {
+  @include ms-fontSize-su;
+}
+
+.ms-fontSize-xxl {
+  @include ms-fontSize-xxl;
+}
+
+.ms-fontSize-xlPlus {
+  @include ms-fontSize-xlPlus;
+}
+
+.ms-fontSize-xl {
+  @include ms-fontSize-xl;
+}
+
+.ms-fontSize-l {
+  @include ms-fontSize-l;
+}
+
+.ms-fontSize-mPlus {
+  @include ms-fontSize-mPlus;
+}
+
+.ms-fontSize-m {
+  @include ms-fontSize-m;
+}
+
+.ms-fontSize-sPlus {
+  @include ms-fontSize-sPlus;
+}
+
+.ms-fontSize-s {
+  @include ms-fontSize-s;
+}
+
+.ms-fontSize-xs {
+  @include ms-fontSize-xs;
+}
+
+.ms-fontSize-mi {
+  @include ms-fontSize-mi;
+}
+
+// Theme colors
+.ms-fontColor-themeDarker,
+.ms-fontColor-themeDarker--hover:hover {
+  @include ms-fontColor-themeDarker;
+}
+
+.ms-fontColor-themeDark,
+.ms-fontColor-themeDark--hover:hover {
+  @include ms-fontColor-themeDark;
+}
+
+.ms-fontColor-themeDarkAlt,
+.ms-fontColor-themeDarkAlt--hover:hover {
+  @include ms-fontColor-themeDarkAlt;
+}
+
+.ms-fontColor-themePrimary,
+.ms-fontColor-themePrimary--hover:hover {
+  @include ms-fontColor-themePrimary;
+}
+
+.ms-fontColor-themeSecondary,
+.ms-fontColor-themeSecondary--hover:hover {
+  @include ms-fontColor-themeSecondary;
+}
+
+.ms-fontColor-themeTertiary,
+.ms-fontColor-themeTertiary--hover:hover {
+  @include ms-fontColor-themeTertiary;
+}
+
+.ms-fontColor-themeLight,
+.ms-fontColor-themeLight--hover:hover {
+  @include ms-fontColor-themeLight;
+}
+
+.ms-fontColor-themeLighter,
+.ms-fontColor-themeLighter--hover:hover {
+  @include ms-fontColor-themeLighter;
+}
+
+.ms-fontColor-themeLighterAlt,
+.ms-fontColor-themeLighterAlt--hover:hover {
+  @include ms-fontColor-themeLighterAlt;
+}
+
+
+// Neutral colors
+.ms-fontColor-black,
+.ms-fontColor-black--hover:hover {
+  @include ms-fontColor-black;
+}
+
+.ms-fontColor-neutralDark,
+.ms-fontColor-neutralDark--hover:hover {
+  @include ms-fontColor-neutralDark;
+}
+
+.ms-fontColor-neutralPrimary,
+.ms-fontColor-neutralPrimary--hover:hover {
+  @include ms-fontColor-neutralPrimary;
+}
+
+.ms-fontColor-neutralPrimaryAlt, 
+.ms-fontColor-neutralPrimaryAlt--hover:hover {
+  @include ms-fontColor-neutralPrimaryAlt;
+}
+
+.ms-fontColor-neutralSecondary, 
+.ms-fontColor-neutralSecondary--hover:hover {
+  @include ms-fontColor-neutralSecondary;
+}
+
+.ms-fontColor-neutralSecondaryAlt,
+.ms-fontColor-neutralSecondaryAlt--hover:hover {
+  @include ms-fontColor-neutralSecondaryAlt;
+}
+
+.ms-fontColor-neutralTertiary,
+.ms-fontColor-neutralTertiary--hover:hover {
+  @include ms-fontColor-neutralTertiary;
+}
+
+.ms-fontColor-neutralTertiaryAlt,
+.ms-fontColor-neutralTertiaryAlt--hover:hover {
+  @include ms-fontColor-neutralTertiaryAlt;
+}
+
+.ms-fontColor-neutralQuaternary,
+.ms-fontColor-neutralQuaternary--hover:hover {
+  @include ms-fontColor-neutralQuaternary;
+}
+
+.ms-fontColor-neutralQuaternaryAlt,
+.ms-fontColor-neutralQuaternaryAlt--hover:hover {
+  @include ms-fontColor-neutralQuaternaryAlt;
+}
+
+.ms-fontColor-neutralLight,
+.ms-fontColor-neutralLight--hover:hover {
+  @include ms-fontColor-neutralLight;
+}
+
+.ms-fontColor-neutralLighter,
+.ms-fontColor-neutralLighter--hover:hover {
+  @include ms-fontColor-neutralLighter;
+}
+
+.ms-fontColor-neutralLighterAlt,
+.ms-fontColor-neutralLighterAlt--hover:hover {
+  @include ms-fontColor-neutralLighterAlt;
+}
+
+.ms-fontColor-white,
+.ms-fontColor-white--hover:hover {
+  @include ms-fontColor-white;
+}
+
+// Brand and accent colors
+.ms-fontColor-yellow,
+.ms-fontColor-yellow--hover:hover {
+  @include ms-fontColor-yellow;
+}
+
+.ms-fontColor-yellowLight,
+.ms-fontColor-yellowLight--hover:hover {
+  @include ms-fontColor-yellowLight;
+}
+
+.ms-fontColor-orange,
+.ms-fontColor-orange--hover:hover {
+  @include ms-fontColor-orange;
+}
+
+.ms-fontColor-orangeLight,
+.ms-fontColor-orangeLight--hover:hover {
+  @include ms-fontColor-orangeLight;
+}
+
+.ms-fontColor-orangeLighter,
+.ms-fontColor-orangeLighter--hover:hover {
+  @include ms-fontColor-orangeLighter;
+}
+
+.ms-fontColor-redDark,
+.ms-fontColor-redDark--hover:hover {
+  @include ms-fontColor-redDark;
+}
+
+.ms-fontColor-red,
+.ms-fontColor-red--hover:hover {
+  @include ms-fontColor-red;
+}
+
+.ms-fontColor-magentaDark,
+.ms-fontColor-magentaDark--hover:hover {
+  @include ms-fontColor-magentaDark;
+}
+
+.ms-fontColor-magenta,
+.ms-fontColor-magenta--hover:hover {
+  @include ms-fontColor-magenta;
+}
+
+.ms-fontColor-magentaLight,
+.ms-fontColor-magentaLight--hover:hover {
+  @include ms-fontColor-magentaLight;
+}
+
+.ms-fontColor-purpleDark,
+.ms-fontColor-purpleDark--hover:hover {
+  @include ms-fontColor-purpleDark;
+}
+
+.ms-fontColor-purple,
+.ms-fontColor-purple--hover:hover {
+  @include ms-fontColor-purple;
+}
+
+.ms-fontColor-purpleLight,
+.ms-fontColor-purpleLight--hover:hover {
+  @include ms-fontColor-purpleLight;
+}
+
+.ms-fontColor-blueDark,
+.ms-fontColor-blueDark--hover:hover {
+  @include ms-fontColor-blueDark;
+}
+
+.ms-fontColor-blueMid,
+.ms-fontColor-blueMid--hover:hover {
+  @include ms-fontColor-blueMid;
+}
+
+.ms-fontColor-blue,
+.ms-fontColor-blue--hover:hover {
+  @include ms-fontColor-blue;
+}
+
+.ms-fontColor-blueLight,
+.ms-fontColor-blueLight--hover:hover {
+  @include ms-fontColor-blueLight;
+}
+
+.ms-fontColor-tealDark,
+.ms-fontColor-tealDark--hover:hover {
+  @include ms-fontColor-tealDark;
+}
+
+.ms-fontColor-teal,
+.ms-fontColor-teal--hover:hover {
+  @include ms-fontColor-teal;
+}
+
+.ms-fontColor-tealLight,
+.ms-fontColor-tealLight--hover:hover {
+  @include ms-fontColor-tealLight;
+}
+
+.ms-fontColor-greenDark,
+.ms-fontColor-greenDark--hover:hover {
+  @include ms-fontColor-greenDark;
+}
+
+.ms-fontColor-green,
+.ms-fontColor-green--hover:hover {
+  @include ms-fontColor-green;
+}
+
+.ms-fontColor-greenLight,
+.ms-fontColor-greenLight--hover:hover {
+  @include ms-fontColor-greenLight;
+}
+
+// Message colors
+.ms-fontColor-info,
+.ms-fontColor-info--hover:hover {
+  @include ms-fontColor-info;
+}
+
+.ms-fontColor-success,
+.ms-fontColor-success--hover:hover {
+  @include ms-fontColor-success;
+}
+
+.ms-fontColor-alert, 
+.ms-fontColor-alert--hover:hover {   // Deprecated: Use ms-fontColor-severeWarning
+   @include ms-fontColor-alert;
+}
+
+.ms-fontColor-warning,
+.ms-fontColor-warning--hover:hover {
+  @include ms-fontColor-warning;
+}
+
+.ms-fontColor-severeWarning,
+.ms-fontColor-severeWarning--hover:hover {
+  @include ms-fontColor-severeWarning;
+}
+
+.ms-fontColor-error,
+.ms-fontColor-error--hover:hover {
+  @include ms-fontColor-error;
+}

--- a/src/sass/_Font.scss
+++ b/src/sass/_Font.scss
@@ -1,407 +1,105 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
+// Deprecated MDL2 font classes.
+@import "./Font.MDL2";
+
+// Font color classes.
 //
-// Office UI Fabric
-// --------------------------------------------------
 
-// Super Styles (LIMITED USE)
-// Weights: Light
-.ms-font-su {
-  @include ms-font-su;
-}
-// No touch class for Super
-
-// Extra-Extra-Large
-// Allowed weights: Light, SemiLight
-.ms-font-xxl {
-  @include ms-font-xxl;
-}
-
-// Extra-Large Plus Styles
-// Allowed weights: Light, SemiLight
-.ms-font-xl-plus {
-  @include ms-font-xl-plus;
-}
-
-// Extra-Large Styles
-// Allowed weights: Light, SemiLight
-.ms-font-xl {
-  @include ms-font-xl;
-}
-
-// Large Styles
-// Allowed weights: SemiLight, Regular, Semibold
-.ms-font-l {
-  @include ms-font-l;
-}
-
-// Medium Plus Styles
-// Allowed weights: SemiLight, Regular, Semibold
-.ms-font-m-plus {
-  @include ms-font-m-plus;
-}
-
-// Medium Styles
-// Allowed weights: SemiLight, Regular, Semibold
-.ms-font-m {
-  @include ms-font-m;
-}
-
-// Small Plus Styles
-// Allowed weights: SemiLight, Regular, Semibold
-.ms-font-s-plus {
-  @include ms-font-s-plus;
-}
-
-// Small Styles
-// Allowed weights: SemiLight, Regular, Semibold
-.ms-font-s {
-  @include ms-font-s;
-}
-
-// XS Styles
-// Allowed weights: SemiLight, Regular, Semibold
-.ms-font-xs {
-  @include ms-font-xs;
-}
-
-// Micro Styles (LIMITED USE)
-// Weights: Semibold
-.ms-font-mi {
-  @include ms-font-mi;
-}
-
-//== Helper classes & mixins
-//
-// Helper mixins to override default type values
-
-// Font weights
-.ms-fontWeight-light {
-  @include ms-fontWeight-light;
-}
-
-.ms-fontWeight-semilight {
-  @include ms-fontWeight-semilight;
-}
-
-.ms-fontWeight-regular {
-  @include ms-fontWeight-regular;
-}
-
-.ms-fontWeight-semibold {
-  @include ms-fontWeight-semibold;
-}
-
-.ms-fontWeight-bold {
-  @include ms-fontWeight-bold;
-}
-
-// Font sizes
-.ms-fontSize-su {
-  @include ms-fontSize-su;
-}
-
-.ms-fontSize-xxl {
-  @include ms-fontSize-xxl;
-}
-
-.ms-fontSize-xlPlus {
-  @include ms-fontSize-xlPlus;
-}
-
-.ms-fontSize-xl {
-  @include ms-fontSize-xl;
-}
-
-.ms-fontSize-l {
-  @include ms-fontSize-l;
-}
-
-.ms-fontSize-mPlus {
-  @include ms-fontSize-mPlus;
-}
-
-.ms-fontSize-m {
-  @include ms-fontSize-m;
-}
-
-.ms-fontSize-sPlus {
-  @include ms-fontSize-sPlus;
-}
-
-.ms-fontSize-s {
-  @include ms-fontSize-s;
-}
-
-.ms-fontSize-xs {
-  @include ms-fontSize-xs;
-}
-
-.ms-fontSize-mi {
-  @include ms-fontSize-mi;
-}
-
-// Theme colors
-.ms-fontColor-themeDarker,
-.ms-fontColor-themeDarker--hover:hover {
-  @include ms-fontColor-themeDarker;
-}
-
-.ms-fontColor-themeDark,
-.ms-fontColor-themeDark--hover:hover {
-  @include ms-fontColor-themeDark;
-}
-
-.ms-fontColor-themeDarkAlt,
-.ms-fontColor-themeDarkAlt--hover:hover {
-  @include ms-fontColor-themeDarkAlt;
-}
-
-.ms-fontColor-themePrimary,
-.ms-fontColor-themePrimary--hover:hover {
-  @include ms-fontColor-themePrimary;
-}
-
-.ms-fontColor-themeSecondary,
-.ms-fontColor-themeSecondary--hover:hover {
-  @include ms-fontColor-themeSecondary;
-}
-
-.ms-fontColor-themeTertiary,
-.ms-fontColor-themeTertiary--hover:hover {
-  @include ms-fontColor-themeTertiary;
-}
-
-.ms-fontColor-themeLight,
-.ms-fontColor-themeLight--hover:hover {
-  @include ms-fontColor-themeLight;
-}
-
-.ms-fontColor-themeLighter,
-.ms-fontColor-themeLighter--hover:hover {
-  @include ms-fontColor-themeLighter;
-}
-
-.ms-fontColor-themeLighterAlt,
-.ms-fontColor-themeLighterAlt--hover:hover {
-  @include ms-fontColor-themeLighterAlt;
-}
-
-
-// Neutral colors
+// Grays.
 .ms-fontColor-black,
 .ms-fontColor-black--hover:hover {
   @include ms-fontColor-black;
 }
-
-.ms-fontColor-neutralDark,
-.ms-fontColor-neutralDark--hover:hover {
-  @include ms-fontColor-neutralDark;
+.ms-fontColor-gray220,
+.ms-fontColor-gray220--hover:hover {
+  @include ms-fontColor-gray220;
 }
-
-.ms-fontColor-neutralPrimary,
-.ms-fontColor-neutralPrimary--hover:hover {
-  @include ms-fontColor-neutralPrimary;
+.ms-fontColor-gray210,
+.ms-fontColor-gray210--hover:hover {
+  @include ms-fontColor-gray210;
 }
-
-.ms-fontColor-neutralPrimaryAlt, 
-.ms-fontColor-neutralPrimaryAlt--hover:hover {
-  @include ms-fontColor-neutralPrimaryAlt;
+.ms-fontColor-gray200,
+.ms-fontColor-gray200--hover:hover {
+  @include ms-fontColor-gray200;
 }
-
-.ms-fontColor-neutralSecondary, 
-.ms-fontColor-neutralSecondary--hover:hover {
-  @include ms-fontColor-neutralSecondary;
+.ms-fontColor-gray190,
+.ms-fontColor-gray190--hover:hover {
+  @include ms-fontColor-gray190;
 }
-
-.ms-fontColor-neutralSecondaryAlt,
-.ms-fontColor-neutralSecondaryAlt--hover:hover {
-  @include ms-fontColor-neutralSecondaryAlt;
+.ms-fontColor-gray180,
+.ms-fontColor-gray180--hover:hover {
+  @include ms-fontColor-gray180;
 }
-
-.ms-fontColor-neutralTertiary,
-.ms-fontColor-neutralTertiary--hover:hover {
-  @include ms-fontColor-neutralTertiary;
+.ms-fontColor-gray170,
+.ms-fontColor-gray170--hover:hover {
+  @include ms-fontColor-gray170;
 }
-
-.ms-fontColor-neutralTertiaryAlt,
-.ms-fontColor-neutralTertiaryAlt--hover:hover {
-  @include ms-fontColor-neutralTertiaryAlt;
+.ms-fontColor-gray160,
+.ms-fontColor-gray160--hover:hover {
+  @include ms-fontColor-gray160;
 }
-
-.ms-fontColor-neutralQuaternary,
-.ms-fontColor-neutralQuaternary--hover:hover {
-  @include ms-fontColor-neutralQuaternary;
+.ms-fontColor-gray150,
+.ms-fontColor-gray150--hover:hover {
+  @include ms-fontColor-gray150;
 }
-
-.ms-fontColor-neutralQuaternaryAlt,
-.ms-fontColor-neutralQuaternaryAlt--hover:hover {
-  @include ms-fontColor-neutralQuaternaryAlt;
+.ms-fontColor-gray140,
+.ms-fontColor-gray140--hover:hover {
+  @include ms-fontColor-gray140;
 }
-
-.ms-fontColor-neutralLight,
-.ms-fontColor-neutralLight--hover:hover {
-  @include ms-fontColor-neutralLight;
+.ms-fontColor-gray130,
+.ms-fontColor-gray130--hover:hover {
+  @include ms-fontColor-gray130;
 }
-
-.ms-fontColor-neutralLighter,
-.ms-fontColor-neutralLighter--hover:hover {
-  @include ms-fontColor-neutralLighter;
+.ms-fontColor-gray120,
+.ms-fontColor-gray120--hover:hover {
+  @include ms-fontColor-gray120;
 }
-
-.ms-fontColor-neutralLighterAlt,
-.ms-fontColor-neutralLighterAlt--hover:hover {
-  @include ms-fontColor-neutralLighterAlt;
+.ms-fontColor-gray110,
+.ms-fontColor-gray110--hover:hover {
+  @include ms-fontColor-gray110;
 }
-
+.ms-fontColor-gray100,
+.ms-fontColor-gray100--hover:hover {
+  @include ms-fontColor-gray100;
+}
+.ms-fontColor-gray90,
+.ms-fontColor-gray90--hover:hover {
+  @include ms-fontColor-gray90;
+}
+.ms-fontColor-gray80,
+.ms-fontColor-gray80--hover:hover {
+  @include ms-fontColor-gray80;
+}
+.ms-fontColor-gray70,
+.ms-fontColor-gray70--hover:hover {
+  @include ms-fontColor-gray70;
+}
+.ms-fontColor-gray60,
+.ms-fontColor-gray60--hover:hover {
+  @include ms-fontColor-gray60;
+}
+.ms-fontColor-gray50,
+.ms-fontColor-gray50--hover:hover {
+  @include ms-fontColor-gray50;
+}
+.ms-fontColor-gray40,
+.ms-fontColor-gray40--hover:hover {
+  @include ms-fontColor-gray40;
+}
+.ms-fontColor-gray30,
+.ms-fontColor-gray30--hover:hover {
+  @include ms-fontColor-gray30;
+}
+.ms-fontColor-gray20,
+.ms-fontColor-gray20--hover:hover {
+  @include ms-fontColor-gray20;
+}
+.ms-fontColor-gray10,
+.ms-fontColor-gray10--hover:hover {
+  @include ms-fontColor-gray10;
+}
 .ms-fontColor-white,
 .ms-fontColor-white--hover:hover {
   @include ms-fontColor-white;
-}
-
-// Brand and accent colors
-.ms-fontColor-yellow,
-.ms-fontColor-yellow--hover:hover {
-  @include ms-fontColor-yellow;
-}
-
-.ms-fontColor-yellowLight,
-.ms-fontColor-yellowLight--hover:hover {
-  @include ms-fontColor-yellowLight;
-}
-
-.ms-fontColor-orange,
-.ms-fontColor-orange--hover:hover {
-  @include ms-fontColor-orange;
-}
-
-.ms-fontColor-orangeLight,
-.ms-fontColor-orangeLight--hover:hover {
-  @include ms-fontColor-orangeLight;
-}
-
-.ms-fontColor-orangeLighter,
-.ms-fontColor-orangeLighter--hover:hover {
-  @include ms-fontColor-orangeLighter;
-}
-
-.ms-fontColor-redDark,
-.ms-fontColor-redDark--hover:hover {
-  @include ms-fontColor-redDark;
-}
-
-.ms-fontColor-red,
-.ms-fontColor-red--hover:hover {
-  @include ms-fontColor-red;
-}
-
-.ms-fontColor-magentaDark,
-.ms-fontColor-magentaDark--hover:hover {
-  @include ms-fontColor-magentaDark;
-}
-
-.ms-fontColor-magenta,
-.ms-fontColor-magenta--hover:hover {
-  @include ms-fontColor-magenta;
-}
-
-.ms-fontColor-magentaLight,
-.ms-fontColor-magentaLight--hover:hover {
-  @include ms-fontColor-magentaLight;
-}
-
-.ms-fontColor-purpleDark,
-.ms-fontColor-purpleDark--hover:hover {
-  @include ms-fontColor-purpleDark;
-}
-
-.ms-fontColor-purple,
-.ms-fontColor-purple--hover:hover {
-  @include ms-fontColor-purple;
-}
-
-.ms-fontColor-purpleLight,
-.ms-fontColor-purpleLight--hover:hover {
-  @include ms-fontColor-purpleLight;
-}
-
-.ms-fontColor-blueDark,
-.ms-fontColor-blueDark--hover:hover {
-  @include ms-fontColor-blueDark;
-}
-
-.ms-fontColor-blueMid,
-.ms-fontColor-blueMid--hover:hover {
-  @include ms-fontColor-blueMid;
-}
-
-.ms-fontColor-blue,
-.ms-fontColor-blue--hover:hover {
-  @include ms-fontColor-blue;
-}
-
-.ms-fontColor-blueLight,
-.ms-fontColor-blueLight--hover:hover {
-  @include ms-fontColor-blueLight;
-}
-
-.ms-fontColor-tealDark,
-.ms-fontColor-tealDark--hover:hover {
-  @include ms-fontColor-tealDark;
-}
-
-.ms-fontColor-teal,
-.ms-fontColor-teal--hover:hover {
-  @include ms-fontColor-teal;
-}
-
-.ms-fontColor-tealLight,
-.ms-fontColor-tealLight--hover:hover {
-  @include ms-fontColor-tealLight;
-}
-
-.ms-fontColor-greenDark,
-.ms-fontColor-greenDark--hover:hover {
-  @include ms-fontColor-greenDark;
-}
-
-.ms-fontColor-green,
-.ms-fontColor-green--hover:hover {
-  @include ms-fontColor-green;
-}
-
-.ms-fontColor-greenLight,
-.ms-fontColor-greenLight--hover:hover {
-  @include ms-fontColor-greenLight;
-}
-
-// Message colors
-.ms-fontColor-info,
-.ms-fontColor-info--hover:hover {
-  @include ms-fontColor-info;
-}
-
-.ms-fontColor-success,
-.ms-fontColor-success--hover:hover {
-  @include ms-fontColor-success;
-}
-
-.ms-fontColor-alert, 
-.ms-fontColor-alert--hover:hover {   // Deprecated: Use ms-fontColor-severeWarning
-   @include ms-fontColor-alert;
-}
-
-.ms-fontColor-warning,
-.ms-fontColor-warning--hover:hover {
-  @include ms-fontColor-warning;
-}
-
-.ms-fontColor-severeWarning,
-.ms-fontColor-severeWarning--hover:hover {
-  @include ms-fontColor-severeWarning;
-}
-
-.ms-fontColor-error,
-.ms-fontColor-error--hover:hover {
-  @include ms-fontColor-error;
 }

--- a/src/sass/mixins/_Color.Mixins.MDL2.scss
+++ b/src/sass/mixins/_Color.Mixins.MDL2.scss
@@ -1,0 +1,428 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+//
+// Office UI Fabric
+// --------------------------------------------------
+// Fabric Core Color Mixins
+
+
+//== Background colors
+//
+// Theme colors
+@mixin ms-bgColor-themeDark {
+  background-color: $ms-color-themeDark;
+}
+
+@mixin ms-bgColor-themeDarkAlt {
+  background-color: $ms-color-themeDarkAlt;
+}
+
+@mixin ms-bgColor-themeDarker {
+  background-color: $ms-color-themeDarker;
+}
+
+@mixin ms-bgColor-themePrimary {
+  background-color: $ms-color-themePrimary;
+}
+
+@mixin ms-bgColor-themeSecondary {
+  background-color: $ms-color-themeSecondary;
+}
+
+@mixin ms-bgColor-themeTertiary {
+  background-color: $ms-color-themeTertiary;
+}
+
+@mixin ms-bgColor-themeLight {
+  background-color: $ms-color-themeLight;
+}
+
+@mixin ms-bgColor-themeLighter {
+  background-color: $ms-color-themeLighter;
+}
+
+@mixin ms-bgColor-themeLighterAlt {
+  background-color: $ms-color-themeLighterAlt;
+}
+
+// Neutral colors
+@mixin ms-bgColor-black {
+  background-color: $ms-color-black;
+}
+
+@mixin ms-bgColor-neutralDark {
+  background-color: $ms-color-neutralDark;
+}
+
+@mixin ms-bgColor-neutralPrimary {
+  background-color: $ms-color-neutralPrimary;
+}
+
+@mixin ms-bgColor-neutralPrimaryAlt {
+  background-color: $ms-color-neutralPrimaryAlt;
+}
+
+@mixin ms-bgColor-neutralSecondary {
+  background-color: $ms-color-neutralSecondary;
+}
+
+@mixin ms-bgColor-neutralSecondaryAlt {
+  background-color: $ms-color-neutralSecondaryAlt;
+}
+
+@mixin ms-bgColor-neutralTertiary {
+  background-color: $ms-color-neutralTertiary;
+}
+
+@mixin ms-bgColor-neutralTertiaryAlt {
+  background-color: $ms-color-neutralTertiaryAlt;
+}
+
+@mixin ms-bgColor-neutralQuaternary {
+  background-color: $ms-color-neutralQuaternary;
+}
+
+@mixin ms-bgColor-neutralQuaternaryAlt {
+  background-color: $ms-color-neutralQuaternaryAlt;
+}
+
+@mixin ms-bgColor-neutralLight {
+  background-color: $ms-color-neutralLight;
+}
+
+@mixin ms-bgColor-neutralLighter {
+  background-color: $ms-color-neutralLighter;
+}
+
+@mixin ms-bgColor-neutralLighterAlt {
+  background-color: $ms-color-neutralLighterAlt;
+}
+
+@mixin ms-bgColor-white {
+  background-color: $ms-color-white;
+}
+
+
+// Brand and accent colors
+@mixin ms-bgColor-yellow {
+  background-color: $ms-color-yellow;
+}
+
+@mixin ms-bgColor-yellowLight {
+  background-color: $ms-color-yellowLight;
+}
+
+@mixin ms-bgColor-orange {
+  background-color: $ms-color-orange;
+}
+
+@mixin ms-bgColor-orangeLight {
+  background-color: $ms-color-orangeLight;
+}
+
+@mixin ms-bgColor-orangeLighter {
+  background-color: $ms-color-orangeLighter;
+}
+
+@mixin ms-bgColor-redDark {
+  background-color: $ms-color-redDark;
+}
+
+@mixin ms-bgColor-red {
+  background-color: $ms-color-red;
+}
+
+@mixin ms-bgColor-magentaDark {
+  background-color: $ms-color-magentaDark;
+}
+
+@mixin ms-bgColor-magenta {
+  background-color: $ms-color-magenta;
+}
+
+@mixin ms-bgColor-magentaLight {
+  background-color: $ms-color-magentaLight;
+}
+
+@mixin ms-bgColor-purpleDark {
+  background-color: $ms-color-purpleDark;
+}
+
+@mixin ms-bgColor-purple {
+  background-color: $ms-color-purple;
+}
+
+@mixin ms-bgColor-purpleLight {
+  background-color: $ms-color-purpleLight;
+}
+
+@mixin ms-bgColor-blueDark {
+  background-color: $ms-color-blueDark;
+}
+
+@mixin ms-bgColor-blueMid {
+  background-color: $ms-color-blueMid;
+}
+
+@mixin ms-bgColor-blue {
+  background-color: $ms-color-blue;
+}
+
+@mixin ms-bgColor-blueLight {
+  background-color: $ms-color-blueLight;
+}
+
+@mixin ms-bgColor-tealDark {
+  background-color: $ms-color-tealDark;
+}
+
+@mixin ms-bgColor-teal {
+  background-color: $ms-color-teal;
+}
+
+@mixin ms-bgColor-tealLight {
+  background-color: $ms-color-tealLight;
+}
+
+@mixin ms-bgColor-greenDark {
+  background-color: $ms-color-greenDark;
+}
+
+@mixin ms-bgColor-green {
+  background-color: $ms-color-green;
+}
+
+@mixin ms-bgColor-greenLight {
+  background-color: $ms-color-greenLight;
+}
+
+// Message colors
+@mixin ms-bgColor-info {
+  background-color: $ms-color-infoBackground;
+}
+
+@mixin ms-bgColor-success {
+  background-color: $ms-color-successBackground;
+}
+
+@mixin ms-bgColor-severeWarning {
+  background-color: $ms-color-severeWarningBackground;
+}
+
+@mixin ms-bgColor-warning {
+  background-color: $ms-color-warningBackground;
+}
+
+@mixin ms-bgColor-error {
+  background-color: $ms-color-errorBackground;
+}
+
+
+//== Border colors
+//
+
+// Theme colors
+@mixin ms-borderColor-themeDark {
+  border-color: $ms-color-themeDark;
+}
+
+@mixin ms-borderColor-themeDarkAlt {
+  border-color: $ms-color-themeDarkAlt;
+}
+
+@mixin ms-borderColor-themeDarker {
+  border-color: $ms-color-themeDarker;
+}
+
+@mixin ms-borderColor-themePrimary {
+  border-color: $ms-color-themePrimary;
+}
+
+@mixin ms-borderColor-themeSecondary {
+  border-color: $ms-color-themeSecondary;
+}
+
+@mixin ms-borderColor-themeTertiary {
+  border-color: $ms-color-themeTertiary;
+}
+
+@mixin ms-borderColor-themeLight {
+  border-color: $ms-color-themeLight;
+}
+
+@mixin ms-borderColor-themeLighter {
+  border-color: $ms-color-themeLighter;
+}
+
+@mixin ms-borderColor-themeLighterAlt {
+  border-color: $ms-color-themeLighterAlt;
+}
+
+
+// Neutral colors
+@mixin ms-borderColor-black {
+  border-color: $ms-color-black;
+}
+
+@mixin ms-borderColor-neutralDark {
+  border-color: $ms-color-neutralDark;
+}
+
+@mixin ms-borderColor-neutralPrimary {
+  border-color: $ms-color-neutralPrimary;
+}
+
+@mixin ms-borderColor-neutralPrimaryAlt {
+  border-color: $ms-color-neutralPrimaryAlt;
+}
+
+@mixin ms-borderColor-neutralSecondary {
+  border-color: $ms-color-neutralSecondary;
+}
+
+@mixin ms-borderColor-neutralSecondaryAlt {
+  border-color: $ms-color-neutralSecondaryAlt;
+}
+
+@mixin ms-borderColor-neutralTertiary {
+  border-color: $ms-color-neutralTertiary;
+}
+
+@mixin ms-borderColor-neutralTertiaryAlt {
+  border-color: $ms-color-neutralTertiaryAlt;
+}
+
+@mixin ms-borderColor-neutralQuaternary {
+  border-color: $ms-color-neutralQuaternary;
+}
+
+@mixin ms-borderColor-neutralQuaternaryAlt {
+  border-color: $ms-color-neutralQuaternaryAlt;
+}
+
+@mixin ms-borderColor-neutralLight {
+  border-color: $ms-color-neutralLight;
+}
+
+@mixin ms-borderColor-neutralLighter {
+  border-color: $ms-color-neutralLighter;
+}
+
+@mixin ms-borderColor-neutralLighterAlt {
+  border-color: $ms-color-neutralLighterAlt;
+}
+
+@mixin ms-borderColor-white {
+  border-color: $ms-color-white;
+}
+
+// Brand and accent colors
+@mixin ms-borderColor-yellow {
+  border-color: $ms-color-yellow;
+}
+
+@mixin ms-borderColor-yellowLight {
+  border-color: $ms-color-yellowLight;
+}
+
+@mixin ms-borderColor-orange {
+  border-color: $ms-color-orange;
+}
+
+@mixin ms-borderColor-orangeLight {
+  border-color: $ms-color-orangeLight;
+}
+
+@mixin ms-borderColor-orangeLighter {
+  border-color: $ms-color-orangeLighter;
+}
+
+@mixin ms-borderColor-redDark {
+  border-color: $ms-color-redDark;
+}
+
+@mixin ms-borderColor-red {
+  border-color: $ms-color-red;
+}
+
+@mixin ms-borderColor-magentaDark {
+  border-color: $ms-color-magentaDark;
+}
+
+@mixin ms-borderColor-magenta {
+  border-color: $ms-color-magenta;
+}
+
+@mixin ms-borderColor-magentaLight {
+  border-color: $ms-color-magentaLight;
+}
+
+@mixin ms-borderColor-purpleDark {
+  border-color: $ms-color-purpleDark;
+}
+
+@mixin ms-borderColor-purple {
+  border-color: $ms-color-purple;
+}
+
+@mixin ms-borderColor-purpleLight {
+  border-color: $ms-color-purpleLight;
+}
+
+@mixin ms-borderColor-blueDark {
+  border-color: $ms-color-blueDark;
+}
+
+@mixin ms-borderColor-blueMid {
+  border-color: $ms-color-blueMid;
+}
+
+@mixin ms-borderColor-blue {
+  border-color: $ms-color-blue;
+}
+
+@mixin ms-borderColor-blueLight {
+  border-color: $ms-color-blueLight;
+}
+
+@mixin ms-borderColor-tealDark {
+  border-color: $ms-color-tealDark;
+}
+
+@mixin ms-borderColor-teal {
+  border-color: $ms-color-teal;
+}
+
+@mixin ms-borderColor-tealLight {
+  border-color: $ms-color-tealLight;
+}
+
+@mixin ms-borderColor-greenDark {
+  border-color: $ms-color-greenDark;
+}
+
+@mixin ms-borderColor-green {
+  border-color: $ms-color-green;
+}
+
+@mixin ms-borderColor-greenLight {
+  border-color: $ms-color-greenLight;
+}
+
+
+// Message colors
+@mixin ms-borderColor-info {
+  border-color: $ms-color-info;
+}
+
+@mixin ms-borderColor-success {
+  border-color: $ms-color-success;
+}
+
+@mixin ms-borderColor-alert {
+  border-color: $ms-color-alert;
+}
+
+@mixin ms-borderColor-error {
+  border-color: $ms-color-error;
+}

--- a/src/sass/mixins/_Color.Mixins.scss
+++ b/src/sass/mixins/_Color.Mixins.scss
@@ -1,428 +1,158 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
+// Deprecated MDL2 color mixins.
+@import "./Color.Mixins.MDL2";
+
+//== Backgrounds.
 //
-// Office UI Fabric
-// --------------------------------------------------
-// Fabric Core Color Mixins
 
-
-//== Background colors
-//
-// Theme colors
-@mixin ms-bgColor-themeDark {
-  background-color: $ms-color-themeDark;
-}
-
-@mixin ms-bgColor-themeDarkAlt {
-  background-color: $ms-color-themeDarkAlt;
-}
-
-@mixin ms-bgColor-themeDarker {
-  background-color: $ms-color-themeDarker;
-}
-
-@mixin ms-bgColor-themePrimary {
-  background-color: $ms-color-themePrimary;
-}
-
-@mixin ms-bgColor-themeSecondary {
-  background-color: $ms-color-themeSecondary;
-}
-
-@mixin ms-bgColor-themeTertiary {
-  background-color: $ms-color-themeTertiary;
-}
-
-@mixin ms-bgColor-themeLight {
-  background-color: $ms-color-themeLight;
-}
-
-@mixin ms-bgColor-themeLighter {
-  background-color: $ms-color-themeLighter;
-}
-
-@mixin ms-bgColor-themeLighterAlt {
-  background-color: $ms-color-themeLighterAlt;
-}
-
-// Neutral colors
+// Grays.
 @mixin ms-bgColor-black {
   background-color: $ms-color-black;
 }
-
-@mixin ms-bgColor-neutralDark {
-  background-color: $ms-color-neutralDark;
+@mixin ms-bgColor-gray220 {
+  background-color: $ms-color-gray220;
 }
-
-@mixin ms-bgColor-neutralPrimary {
-  background-color: $ms-color-neutralPrimary;
+@mixin ms-bgColor-gray210 {
+  background-color: $ms-color-gray210;
 }
-
-@mixin ms-bgColor-neutralPrimaryAlt {
-  background-color: $ms-color-neutralPrimaryAlt;
+@mixin ms-bgColor-gray200 {
+  background-color: $ms-color-gray200;
 }
-
-@mixin ms-bgColor-neutralSecondary {
-  background-color: $ms-color-neutralSecondary;
+@mixin ms-bgColor-gray190 {
+  background-color: $ms-color-gray190;
 }
-
-@mixin ms-bgColor-neutralSecondaryAlt {
-  background-color: $ms-color-neutralSecondaryAlt;
+@mixin ms-bgColor-gray180 {
+  background-color: $ms-color-gray180;
 }
-
-@mixin ms-bgColor-neutralTertiary {
-  background-color: $ms-color-neutralTertiary;
+@mixin ms-bgColor-gray170 {
+  background-color: $ms-color-gray170;
 }
-
-@mixin ms-bgColor-neutralTertiaryAlt {
-  background-color: $ms-color-neutralTertiaryAlt;
+@mixin ms-bgColor-gray160 {
+  background-color: $ms-color-gray160;
 }
-
-@mixin ms-bgColor-neutralQuaternary {
-  background-color: $ms-color-neutralQuaternary;
+@mixin ms-bgColor-gray150 {
+  background-color: $ms-color-gray150;
 }
-
-@mixin ms-bgColor-neutralQuaternaryAlt {
-  background-color: $ms-color-neutralQuaternaryAlt;
+@mixin ms-bgColor-gray140 {
+  background-color: $ms-color-gray140;
 }
-
-@mixin ms-bgColor-neutralLight {
-  background-color: $ms-color-neutralLight;
+@mixin ms-bgColor-gray130 {
+  background-color: $ms-color-gray130;
 }
-
-@mixin ms-bgColor-neutralLighter {
-  background-color: $ms-color-neutralLighter;
+@mixin ms-bgColor-gray120 {
+  background-color: $ms-color-gray120;
 }
-
-@mixin ms-bgColor-neutralLighterAlt {
-  background-color: $ms-color-neutralLighterAlt;
+@mixin ms-bgColor-gray110 {
+  background-color: $ms-color-gray110;
 }
-
+@mixin ms-bgColor-gray100 {
+  background-color: $ms-color-gray100;
+}
+@mixin ms-bgColor-gray90 {
+  background-color: $ms-color-gray90;
+}
+@mixin ms-bgColor-gray80 {
+  background-color: $ms-color-gray80;
+}
+@mixin ms-bgColor-gray70 {
+  background-color: $ms-color-gray70;
+}
+@mixin ms-bgColor-gray60 {
+  background-color: $ms-color-gray60;
+}
+@mixin ms-bgColor-gray50 {
+  background-color: $ms-color-gray50;
+}
+@mixin ms-bgColor-gray40 {
+  background-color: $ms-color-gray40;
+}
+@mixin ms-bgColor-gray30 {
+  background-color: $ms-color-gray30;
+}
+@mixin ms-bgColor-gray20 {
+  background-color: $ms-color-gray20;
+}
+@mixin ms-bgColor-gray10 {
+  background-color: $ms-color-gray10;
+}
 @mixin ms-bgColor-white {
   background-color: $ms-color-white;
 }
 
-
-// Brand and accent colors
-@mixin ms-bgColor-yellow {
-  background-color: $ms-color-yellow;
-}
-
-@mixin ms-bgColor-yellowLight {
-  background-color: $ms-color-yellowLight;
-}
-
-@mixin ms-bgColor-orange {
-  background-color: $ms-color-orange;
-}
-
-@mixin ms-bgColor-orangeLight {
-  background-color: $ms-color-orangeLight;
-}
-
-@mixin ms-bgColor-orangeLighter {
-  background-color: $ms-color-orangeLighter;
-}
-
-@mixin ms-bgColor-redDark {
-  background-color: $ms-color-redDark;
-}
-
-@mixin ms-bgColor-red {
-  background-color: $ms-color-red;
-}
-
-@mixin ms-bgColor-magentaDark {
-  background-color: $ms-color-magentaDark;
-}
-
-@mixin ms-bgColor-magenta {
-  background-color: $ms-color-magenta;
-}
-
-@mixin ms-bgColor-magentaLight {
-  background-color: $ms-color-magentaLight;
-}
-
-@mixin ms-bgColor-purpleDark {
-  background-color: $ms-color-purpleDark;
-}
-
-@mixin ms-bgColor-purple {
-  background-color: $ms-color-purple;
-}
-
-@mixin ms-bgColor-purpleLight {
-  background-color: $ms-color-purpleLight;
-}
-
-@mixin ms-bgColor-blueDark {
-  background-color: $ms-color-blueDark;
-}
-
-@mixin ms-bgColor-blueMid {
-  background-color: $ms-color-blueMid;
-}
-
-@mixin ms-bgColor-blue {
-  background-color: $ms-color-blue;
-}
-
-@mixin ms-bgColor-blueLight {
-  background-color: $ms-color-blueLight;
-}
-
-@mixin ms-bgColor-tealDark {
-  background-color: $ms-color-tealDark;
-}
-
-@mixin ms-bgColor-teal {
-  background-color: $ms-color-teal;
-}
-
-@mixin ms-bgColor-tealLight {
-  background-color: $ms-color-tealLight;
-}
-
-@mixin ms-bgColor-greenDark {
-  background-color: $ms-color-greenDark;
-}
-
-@mixin ms-bgColor-green {
-  background-color: $ms-color-green;
-}
-
-@mixin ms-bgColor-greenLight {
-  background-color: $ms-color-greenLight;
-}
-
-// Message colors
-@mixin ms-bgColor-info {
-  background-color: $ms-color-infoBackground;
-}
-
-@mixin ms-bgColor-success {
-  background-color: $ms-color-successBackground;
-}
-
-@mixin ms-bgColor-severeWarning {
-  background-color: $ms-color-severeWarningBackground;
-}
-
-@mixin ms-bgColor-warning {
-  background-color: $ms-color-warningBackground;
-}
-
-@mixin ms-bgColor-error {
-  background-color: $ms-color-errorBackground;
-}
-
-
-//== Border colors
+//== Borders.
 //
 
-// Theme colors
-@mixin ms-borderColor-themeDark {
-  border-color: $ms-color-themeDark;
-}
-
-@mixin ms-borderColor-themeDarkAlt {
-  border-color: $ms-color-themeDarkAlt;
-}
-
-@mixin ms-borderColor-themeDarker {
-  border-color: $ms-color-themeDarker;
-}
-
-@mixin ms-borderColor-themePrimary {
-  border-color: $ms-color-themePrimary;
-}
-
-@mixin ms-borderColor-themeSecondary {
-  border-color: $ms-color-themeSecondary;
-}
-
-@mixin ms-borderColor-themeTertiary {
-  border-color: $ms-color-themeTertiary;
-}
-
-@mixin ms-borderColor-themeLight {
-  border-color: $ms-color-themeLight;
-}
-
-@mixin ms-borderColor-themeLighter {
-  border-color: $ms-color-themeLighter;
-}
-
-@mixin ms-borderColor-themeLighterAlt {
-  border-color: $ms-color-themeLighterAlt;
-}
-
-
-// Neutral colors
+// Grays.
 @mixin ms-borderColor-black {
   border-color: $ms-color-black;
 }
-
-@mixin ms-borderColor-neutralDark {
-  border-color: $ms-color-neutralDark;
+@mixin ms-borderColor-gray220 {
+  border-color: $ms-color-gray220;
 }
-
-@mixin ms-borderColor-neutralPrimary {
-  border-color: $ms-color-neutralPrimary;
+@mixin ms-borderColor-gray210 {
+  border-color: $ms-color-gray210;
 }
-
-@mixin ms-borderColor-neutralPrimaryAlt {
-  border-color: $ms-color-neutralPrimaryAlt;
+@mixin ms-borderColor-gray200 {
+  border-color: $ms-color-gray200;
 }
-
-@mixin ms-borderColor-neutralSecondary {
-  border-color: $ms-color-neutralSecondary;
+@mixin ms-borderColor-gray190 {
+  border-color: $ms-color-gray190;
 }
-
-@mixin ms-borderColor-neutralSecondaryAlt {
-  border-color: $ms-color-neutralSecondaryAlt;
+@mixin ms-borderColor-gray180 {
+  border-color: $ms-color-gray180;
 }
-
-@mixin ms-borderColor-neutralTertiary {
-  border-color: $ms-color-neutralTertiary;
+@mixin ms-borderColor-gray170 {
+  border-color: $ms-color-gray170;
 }
-
-@mixin ms-borderColor-neutralTertiaryAlt {
-  border-color: $ms-color-neutralTertiaryAlt;
+@mixin ms-borderColor-gray160 {
+  border-color: $ms-color-gray160;
 }
-
-@mixin ms-borderColor-neutralQuaternary {
-  border-color: $ms-color-neutralQuaternary;
+@mixin ms-borderColor-gray150 {
+  border-color: $ms-color-gray150;
 }
-
-@mixin ms-borderColor-neutralQuaternaryAlt {
-  border-color: $ms-color-neutralQuaternaryAlt;
+@mixin ms-borderColor-gray140 {
+  border-color: $ms-color-gray140;
 }
-
-@mixin ms-borderColor-neutralLight {
-  border-color: $ms-color-neutralLight;
+@mixin ms-borderColor-gray130 {
+  border-color: $ms-color-gray130;
 }
-
-@mixin ms-borderColor-neutralLighter {
-  border-color: $ms-color-neutralLighter;
+@mixin ms-borderColor-gray120 {
+  border-color: $ms-color-gray120;
 }
-
-@mixin ms-borderColor-neutralLighterAlt {
-  border-color: $ms-color-neutralLighterAlt;
+@mixin ms-borderColor-gray110 {
+  border-color: $ms-color-gray110;
 }
-
+@mixin ms-borderColor-gray100 {
+  border-color: $ms-color-gray100;
+}
+@mixin ms-borderColor-gray90 {
+  border-color: $ms-color-gray90;
+}
+@mixin ms-borderColor-gray80 {
+  border-color: $ms-color-gray80;
+}
+@mixin ms-borderColor-gray70 {
+  border-color: $ms-color-gray70;
+}
+@mixin ms-borderColor-gray60 {
+  border-color: $ms-color-gray60;
+}
+@mixin ms-borderColor-gray50 {
+  border-color: $ms-color-gray50;
+}
+@mixin ms-borderColor-gray40 {
+  border-color: $ms-color-gray40;
+}
+@mixin ms-borderColor-gray30 {
+  border-color: $ms-color-gray30;
+}
+@mixin ms-borderColor-gray20 {
+  border-color: $ms-color-gray20;
+}
+@mixin ms-borderColor-gray10 {
+  border-color: $ms-color-gray10;
+}
 @mixin ms-borderColor-white {
   border-color: $ms-color-white;
-}
-
-// Brand and accent colors
-@mixin ms-borderColor-yellow {
-  border-color: $ms-color-yellow;
-}
-
-@mixin ms-borderColor-yellowLight {
-  border-color: $ms-color-yellowLight;
-}
-
-@mixin ms-borderColor-orange {
-  border-color: $ms-color-orange;
-}
-
-@mixin ms-borderColor-orangeLight {
-  border-color: $ms-color-orangeLight;
-}
-
-@mixin ms-borderColor-orangeLighter {
-  border-color: $ms-color-orangeLighter;
-}
-
-@mixin ms-borderColor-redDark {
-  border-color: $ms-color-redDark;
-}
-
-@mixin ms-borderColor-red {
-  border-color: $ms-color-red;
-}
-
-@mixin ms-borderColor-magentaDark {
-  border-color: $ms-color-magentaDark;
-}
-
-@mixin ms-borderColor-magenta {
-  border-color: $ms-color-magenta;
-}
-
-@mixin ms-borderColor-magentaLight {
-  border-color: $ms-color-magentaLight;
-}
-
-@mixin ms-borderColor-purpleDark {
-  border-color: $ms-color-purpleDark;
-}
-
-@mixin ms-borderColor-purple {
-  border-color: $ms-color-purple;
-}
-
-@mixin ms-borderColor-purpleLight {
-  border-color: $ms-color-purpleLight;
-}
-
-@mixin ms-borderColor-blueDark {
-  border-color: $ms-color-blueDark;
-}
-
-@mixin ms-borderColor-blueMid {
-  border-color: $ms-color-blueMid;
-}
-
-@mixin ms-borderColor-blue {
-  border-color: $ms-color-blue;
-}
-
-@mixin ms-borderColor-blueLight {
-  border-color: $ms-color-blueLight;
-}
-
-@mixin ms-borderColor-tealDark {
-  border-color: $ms-color-tealDark;
-}
-
-@mixin ms-borderColor-teal {
-  border-color: $ms-color-teal;
-}
-
-@mixin ms-borderColor-tealLight {
-  border-color: $ms-color-tealLight;
-}
-
-@mixin ms-borderColor-greenDark {
-  border-color: $ms-color-greenDark;
-}
-
-@mixin ms-borderColor-green {
-  border-color: $ms-color-green;
-}
-
-@mixin ms-borderColor-greenLight {
-  border-color: $ms-color-greenLight;
-}
-
-
-// Message colors
-@mixin ms-borderColor-info {
-  border-color: $ms-color-info;
-}
-
-@mixin ms-borderColor-success {
-  border-color: $ms-color-success;
-}
-
-@mixin ms-borderColor-alert {
-  border-color: $ms-color-alert;
-}
-
-@mixin ms-borderColor-error {
-  border-color: $ms-color-error;
 }

--- a/src/sass/mixins/_Font.Mixins.MDL2.scss
+++ b/src/sass/mixins/_Font.Mixins.MDL2.scss
@@ -1,0 +1,411 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+//
+// Office UI Fabric
+// --------------------------------------------------
+// Font definitions
+
+/*
+  Your use of the content in the files referenced here is subject to the terms of the license at http://aka.ms/fabric-assets-license
+*/
+
+// Produce @font-face definitions for the web fonts.
+@mixin ms-font-face($font-family-name, $cdn-folder, $cdn-font-name: 'segoeui') {
+  @font-face {
+    font-family: $font-family-name;
+    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-light.woff2') format('woff2'),
+         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-light.woff') format('woff');
+    font-weight: $ms-font-weight-light;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: $font-family-name;
+    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semilight.woff2') format('woff2'),
+         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semilight.woff') format('woff');
+    font-weight: $ms-font-weight-semilight;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: $font-family-name;
+    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-regular.woff2') format('woff2'),
+         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-regular.woff') format('woff');
+    font-weight: $ms-font-weight-regular;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: $font-family-name;
+    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semibold.woff2') format('woff2'),
+         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semibold.woff') format('woff');
+    font-weight: $ms-font-weight-semibold;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: $font-family-name;
+    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-bold.woff2') format('woff2'),
+         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-bold.woff') format('woff');
+    font-weight: $ms-font-weight-bold;
+    font-style: normal;
+  }
+}
+
+// Generate overrides to set font-family based on the lang attribute.
+@mixin ms-font-family-language-override($language-code, $font-family) {
+  *[lang^='#{$language-code}'] .ms-Fabric,
+  .ms-Fabric *[lang^='#{$language-code}'],
+  .ms-Fabric[lang^='#{$language-code}'] {
+    font-family: $font-family;
+  }
+}
+
+// Super Styles (LIMITED USE)
+@mixin ms-font-su {
+  font-size: $ms-font-size-su;
+  font-weight: $ms-font-weight-light;
+}
+
+// Extra-Extra-Large
+@mixin ms-font-xxl {
+  font-size: $ms-font-size-xxl;
+  font-weight: $ms-font-weight-light;
+}
+
+// Extra-Large Styles
+@mixin ms-font-xl-plus {
+  font-size: $ms-font-size-xl-plus;
+  font-weight: $ms-font-weight-light;
+}
+
+// Extra-Large Styles
+@mixin ms-font-xl {
+  font-size: $ms-font-size-xl;
+  font-weight: $ms-font-weight-light;
+}
+
+// Large Styles
+@mixin ms-font-l {
+  font-size: $ms-font-size-l;
+  font-weight: $ms-font-weight-semilight;
+}
+
+// Medium Plus Styles
+@mixin ms-font-m-plus {
+  font-size: $ms-font-size-m-plus;
+  font-weight: $ms-font-weight-regular;
+}
+
+// Medium Styles
+@mixin ms-font-m {
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
+}
+
+// Small Plus Styles
+@mixin ms-font-s-plus {
+  font-size: $ms-font-size-s-plus;
+  font-weight: $ms-font-weight-regular;
+}
+
+// Small Styles
+@mixin ms-font-s {
+  font-size: $ms-font-size-s;
+  font-weight: $ms-font-weight-regular;
+}
+
+// XS Styles
+@mixin ms-font-xs {
+  font-size: $ms-font-size-xs;
+  font-weight: $ms-font-weight-regular;
+}
+
+// Micro Styles (LIMITED USE)
+@mixin ms-font-mi {
+  font-size: $ms-font-size-mi;
+  font-weight: $ms-font-weight-semibold;
+}
+
+//== Helper classes & mixins
+//
+// Helper mixins to override default type values
+
+// Font weights
+@mixin ms-fontWeight-light {
+  font-weight: $ms-font-weight-light;
+}
+
+@mixin ms-fontWeight-semilight {
+  font-weight: $ms-font-weight-semilight;
+}
+
+@mixin ms-fontWeight-regular {
+  font-weight: $ms-font-weight-regular;
+}
+
+@mixin ms-fontWeight-semibold {
+  font-weight: $ms-font-weight-semibold;
+}
+
+@mixin ms-fontWeight-bold {
+  font-weight: $ms-font-weight-bold;
+}
+
+// Font sizes
+@mixin ms-fontSize-su {
+  font-size: $ms-font-size-su;
+}
+
+@mixin ms-fontSize-xxl {
+  font-size: $ms-font-size-xxl;
+}
+
+@mixin ms-fontSize-xlPlus {
+  font-size: $ms-font-size-xl-plus;
+}
+
+@mixin ms-fontSize-xl {
+  font-size: $ms-font-size-xl;
+}
+
+@mixin ms-fontSize-l {
+  font-size: $ms-font-size-l;
+}
+
+@mixin ms-fontSize-mPlus {
+  font-size: $ms-font-size-m-plus;
+}
+
+@mixin ms-fontSize-m {
+  font-size: $ms-font-size-m;
+}
+
+@mixin ms-fontSize-sPlus {
+  font-size: $ms-font-size-s-plus;
+}
+
+@mixin ms-fontSize-s {
+  font-size: $ms-font-size-s;
+}
+
+@mixin ms-fontSize-xs {
+  font-size: $ms-font-size-xs;
+}
+
+@mixin ms-fontSize-mi {
+  font-size: $ms-font-size-mi;
+}
+
+// Theme colors
+@mixin ms-fontColor-themeDarker {
+  color: $ms-color-themeDarker;
+}
+
+@mixin ms-fontColor-themeDark {
+  color: $ms-color-themeDark;
+}
+
+@mixin ms-fontColor-themeDarkAlt {
+  color: $ms-color-themeDarkAlt;
+}
+
+@mixin ms-fontColor-themePrimary {
+  color: $ms-color-themePrimary;
+}
+
+@mixin ms-fontColor-themeSecondary {
+  color: $ms-color-themeSecondary;
+}
+
+@mixin ms-fontColor-themeTertiary {
+  color: $ms-color-themeTertiary;
+}
+
+@mixin ms-fontColor-themeLight {
+  color: $ms-color-themeLight;
+}
+
+@mixin ms-fontColor-themeLighter {
+  color: $ms-color-themeLighter;
+}
+
+@mixin ms-fontColor-themeLighterAlt {
+  color: $ms-color-themeLighterAlt;
+}
+
+
+// Neutral colors
+@mixin ms-fontColor-black {
+  color: $ms-color-black;
+}
+
+@mixin ms-fontColor-neutralDark {
+  color: $ms-color-neutralDark;
+}
+
+@mixin ms-fontColor-neutralPrimary {
+  color: $ms-color-neutralPrimary;
+}
+
+@mixin ms-fontColor-neutralPrimaryAlt {
+  color: $ms-color-neutralPrimaryAlt;
+}
+
+@mixin ms-fontColor-neutralSecondary {
+ color: $ms-color-neutralSecondary;
+}
+
+@mixin ms-fontColor-neutralSecondaryAlt {
+  color: $ms-color-neutralSecondaryAlt;
+}
+
+@mixin ms-fontColor-neutralTertiary {
+  color: $ms-color-neutralTertiary;
+}
+
+@mixin ms-fontColor-neutralTertiaryAlt {
+  color: $ms-color-neutralTertiaryAlt;
+}
+
+@mixin ms-fontColor-neutralQuaternary {
+  color: $ms-color-neutralQuaternary;
+}
+
+@mixin ms-fontColor-neutralQuaternaryAlt {
+  color: $ms-color-neutralQuaternaryAlt;
+}
+
+@mixin ms-fontColor-neutralLight {
+  color: $ms-color-neutralLight;
+}
+
+@mixin ms-fontColor-neutralLighter {
+  color: $ms-color-neutralLighter;
+}
+
+@mixin ms-fontColor-neutralLighterAlt {
+  color: $ms-color-neutralLighterAlt;
+}
+
+@mixin ms-fontColor-white {
+  color: $ms-color-white;
+}
+
+// Brand and accent colors
+@mixin ms-fontColor-yellow {
+  color: $ms-color-yellow;
+}
+
+@mixin ms-fontColor-yellowLight {
+  color: $ms-color-yellowLight;
+}
+
+@mixin ms-fontColor-orange {
+  color: $ms-color-orange;
+}
+
+@mixin ms-fontColor-orangeLight {
+  color: $ms-color-orangeLight;
+}
+
+@mixin ms-fontColor-orangeLighter {
+  color: $ms-color-orangeLighter;
+}
+
+@mixin ms-fontColor-redDark {
+  color: $ms-color-redDark;
+}
+
+@mixin ms-fontColor-red {
+  color: $ms-color-red;
+}
+
+@mixin ms-fontColor-magentaDark {
+  color: $ms-color-magentaDark;
+}
+
+@mixin ms-fontColor-magenta {
+  color: $ms-color-magenta;
+}
+
+@mixin ms-fontColor-magentaLight {
+  color: $ms-color-magentaLight;
+}
+
+@mixin ms-fontColor-purpleDark {
+  color: $ms-color-purpleDark;
+}
+
+@mixin ms-fontColor-purple {
+  color: $ms-color-purple;
+}
+
+@mixin ms-fontColor-purpleLight {
+  color: $ms-color-purpleLight;
+}
+
+@mixin ms-fontColor-blueDark {
+  color: $ms-color-blueDark;
+}
+
+@mixin ms-fontColor-blueMid {
+  color: $ms-color-blueMid;
+}
+
+@mixin ms-fontColor-blue {
+  color: $ms-color-blue;
+}
+
+@mixin ms-fontColor-blueLight {
+  color: $ms-color-blueLight;
+}
+
+@mixin ms-fontColor-tealDark {
+  color: $ms-color-tealDark;
+}
+
+@mixin ms-fontColor-teal {
+  color: $ms-color-teal;
+}
+
+@mixin ms-fontColor-tealLight {
+  color: $ms-color-tealLight;
+}
+
+@mixin ms-fontColor-greenDark {
+  color: $ms-color-greenDark;
+}
+
+@mixin ms-fontColor-green {
+  color: $ms-color-green;
+}
+
+@mixin ms-fontColor-greenLight {
+  color: $ms-color-greenLight;
+}
+
+// Message colors
+@mixin ms-fontColor-info {
+  color: $ms-color-info;
+}
+
+@mixin ms-fontColor-success {
+  color: $ms-color-success;
+}
+
+@mixin ms-fontColor-alert { // @todo: Deprecated: Use ms-fontColor-severeWarning
+  color: $ms-color-alert;
+}
+
+@mixin ms-fontColor-warning {
+  color: $ms-color-warning;
+}
+
+@mixin ms-fontColor-severeWarning {
+  color: $ms-color-severeWarning;
+}
+
+@mixin ms-fontColor-error {
+  color: $ms-color-error;
+}

--- a/src/sass/mixins/_Font.Mixins.scss
+++ b/src/sass/mixins/_Font.Mixins.scss
@@ -1,411 +1,81 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
+// Deprecated MDL2 font mixins.
+@import "./Font.Mixins.MDL2";
+
+//== Font color.
 //
-// Office UI Fabric
-// --------------------------------------------------
-// Font definitions
 
-/*
-  Your use of the content in the files referenced here is subject to the terms of the license at http://aka.ms/fabric-assets-license
-*/
-
-// Produce @font-face definitions for the web fonts.
-@mixin ms-font-face($font-family-name, $cdn-folder, $cdn-font-name: 'segoeui') {
-  @font-face {
-    font-family: $font-family-name;
-    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-light.woff2') format('woff2'),
-         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-light.woff') format('woff');
-    font-weight: $ms-font-weight-light;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: $font-family-name;
-    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semilight.woff2') format('woff2'),
-         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semilight.woff') format('woff');
-    font-weight: $ms-font-weight-semilight;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: $font-family-name;
-    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-regular.woff2') format('woff2'),
-         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-regular.woff') format('woff');
-    font-weight: $ms-font-weight-regular;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: $font-family-name;
-    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semibold.woff2') format('woff2'),
-         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-semibold.woff') format('woff');
-    font-weight: $ms-font-weight-semibold;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: $font-family-name;
-    src: url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-bold.woff2') format('woff2'),
-         url('#{$ms-font-cdn-path}/#{$cdn-folder}/#{$cdn-font-name}-bold.woff') format('woff');
-    font-weight: $ms-font-weight-bold;
-    font-style: normal;
-  }
-}
-
-// Generate overrides to set font-family based on the lang attribute.
-@mixin ms-font-family-language-override($language-code, $font-family) {
-  *[lang^='#{$language-code}'] .ms-Fabric,
-  .ms-Fabric *[lang^='#{$language-code}'],
-  .ms-Fabric[lang^='#{$language-code}'] {
-    font-family: $font-family;
-  }
-}
-
-// Super Styles (LIMITED USE)
-@mixin ms-font-su {
-  font-size: $ms-font-size-su;
-  font-weight: $ms-font-weight-light;
-}
-
-// Extra-Extra-Large
-@mixin ms-font-xxl {
-  font-size: $ms-font-size-xxl;
-  font-weight: $ms-font-weight-light;
-}
-
-// Extra-Large Styles
-@mixin ms-font-xl-plus {
-  font-size: $ms-font-size-xl-plus;
-  font-weight: $ms-font-weight-light;
-}
-
-// Extra-Large Styles
-@mixin ms-font-xl {
-  font-size: $ms-font-size-xl;
-  font-weight: $ms-font-weight-light;
-}
-
-// Large Styles
-@mixin ms-font-l {
-  font-size: $ms-font-size-l;
-  font-weight: $ms-font-weight-semilight;
-}
-
-// Medium Plus Styles
-@mixin ms-font-m-plus {
-  font-size: $ms-font-size-m-plus;
-  font-weight: $ms-font-weight-regular;
-}
-
-// Medium Styles
-@mixin ms-font-m {
-  font-size: $ms-font-size-m;
-  font-weight: $ms-font-weight-regular;
-}
-
-// Small Plus Styles
-@mixin ms-font-s-plus {
-  font-size: $ms-font-size-s-plus;
-  font-weight: $ms-font-weight-regular;
-}
-
-// Small Styles
-@mixin ms-font-s {
-  font-size: $ms-font-size-s;
-  font-weight: $ms-font-weight-regular;
-}
-
-// XS Styles
-@mixin ms-font-xs {
-  font-size: $ms-font-size-xs;
-  font-weight: $ms-font-weight-regular;
-}
-
-// Micro Styles (LIMITED USE)
-@mixin ms-font-mi {
-  font-size: $ms-font-size-mi;
-  font-weight: $ms-font-weight-semibold;
-}
-
-//== Helper classes & mixins
-//
-// Helper mixins to override default type values
-
-// Font weights
-@mixin ms-fontWeight-light {
-  font-weight: $ms-font-weight-light;
-}
-
-@mixin ms-fontWeight-semilight {
-  font-weight: $ms-font-weight-semilight;
-}
-
-@mixin ms-fontWeight-regular {
-  font-weight: $ms-font-weight-regular;
-}
-
-@mixin ms-fontWeight-semibold {
-  font-weight: $ms-font-weight-semibold;
-}
-
-@mixin ms-fontWeight-bold {
-  font-weight: $ms-font-weight-bold;
-}
-
-// Font sizes
-@mixin ms-fontSize-su {
-  font-size: $ms-font-size-su;
-}
-
-@mixin ms-fontSize-xxl {
-  font-size: $ms-font-size-xxl;
-}
-
-@mixin ms-fontSize-xlPlus {
-  font-size: $ms-font-size-xl-plus;
-}
-
-@mixin ms-fontSize-xl {
-  font-size: $ms-font-size-xl;
-}
-
-@mixin ms-fontSize-l {
-  font-size: $ms-font-size-l;
-}
-
-@mixin ms-fontSize-mPlus {
-  font-size: $ms-font-size-m-plus;
-}
-
-@mixin ms-fontSize-m {
-  font-size: $ms-font-size-m;
-}
-
-@mixin ms-fontSize-sPlus {
-  font-size: $ms-font-size-s-plus;
-}
-
-@mixin ms-fontSize-s {
-  font-size: $ms-font-size-s;
-}
-
-@mixin ms-fontSize-xs {
-  font-size: $ms-font-size-xs;
-}
-
-@mixin ms-fontSize-mi {
-  font-size: $ms-font-size-mi;
-}
-
-// Theme colors
-@mixin ms-fontColor-themeDarker {
-  color: $ms-color-themeDarker;
-}
-
-@mixin ms-fontColor-themeDark {
-  color: $ms-color-themeDark;
-}
-
-@mixin ms-fontColor-themeDarkAlt {
-  color: $ms-color-themeDarkAlt;
-}
-
-@mixin ms-fontColor-themePrimary {
-  color: $ms-color-themePrimary;
-}
-
-@mixin ms-fontColor-themeSecondary {
-  color: $ms-color-themeSecondary;
-}
-
-@mixin ms-fontColor-themeTertiary {
-  color: $ms-color-themeTertiary;
-}
-
-@mixin ms-fontColor-themeLight {
-  color: $ms-color-themeLight;
-}
-
-@mixin ms-fontColor-themeLighter {
-  color: $ms-color-themeLighter;
-}
-
-@mixin ms-fontColor-themeLighterAlt {
-  color: $ms-color-themeLighterAlt;
-}
-
-
-// Neutral colors
+// Grays.
 @mixin ms-fontColor-black {
   color: $ms-color-black;
 }
-
-@mixin ms-fontColor-neutralDark {
-  color: $ms-color-neutralDark;
+@mixin ms-fontColor-gray220 {
+  color: $ms-color-gray220;
 }
-
-@mixin ms-fontColor-neutralPrimary {
-  color: $ms-color-neutralPrimary;
+@mixin ms-fontColor-gray210 {
+  color: $ms-color-gray210;
 }
-
-@mixin ms-fontColor-neutralPrimaryAlt {
-  color: $ms-color-neutralPrimaryAlt;
+@mixin ms-fontColor-gray200 {
+  color: $ms-color-gray200;
 }
-
-@mixin ms-fontColor-neutralSecondary {
- color: $ms-color-neutralSecondary;
+@mixin ms-fontColor-gray190 {
+  color: $ms-color-gray190;
 }
-
-@mixin ms-fontColor-neutralSecondaryAlt {
-  color: $ms-color-neutralSecondaryAlt;
+@mixin ms-fontColor-gray180 {
+  color: $ms-color-gray180;
 }
-
-@mixin ms-fontColor-neutralTertiary {
-  color: $ms-color-neutralTertiary;
+@mixin ms-fontColor-gray170 {
+  color: $ms-color-gray170;
 }
-
-@mixin ms-fontColor-neutralTertiaryAlt {
-  color: $ms-color-neutralTertiaryAlt;
+@mixin ms-fontColor-gray160 {
+  color: $ms-color-gray160;
 }
-
-@mixin ms-fontColor-neutralQuaternary {
-  color: $ms-color-neutralQuaternary;
+@mixin ms-fontColor-gray150 {
+  color: $ms-color-gray150;
 }
-
-@mixin ms-fontColor-neutralQuaternaryAlt {
-  color: $ms-color-neutralQuaternaryAlt;
+@mixin ms-fontColor-gray140 {
+  color: $ms-color-gray140;
 }
-
-@mixin ms-fontColor-neutralLight {
-  color: $ms-color-neutralLight;
+@mixin ms-fontColor-gray130 {
+  color: $ms-color-gray130;
 }
-
-@mixin ms-fontColor-neutralLighter {
-  color: $ms-color-neutralLighter;
+@mixin ms-fontColor-gray120 {
+  color: $ms-color-gray120;
 }
-
-@mixin ms-fontColor-neutralLighterAlt {
-  color: $ms-color-neutralLighterAlt;
+@mixin ms-fontColor-gray110 {
+  color: $ms-color-gray110;
 }
-
+@mixin ms-fontColor-gray100 {
+  color: $ms-color-gray100;
+}
+@mixin ms-fontColor-gray90 {
+  color: $ms-color-gray90;
+}
+@mixin ms-fontColor-gray80 {
+  color: $ms-color-gray80;
+}
+@mixin ms-fontColor-gray70 {
+  color: $ms-color-gray70;
+}
+@mixin ms-fontColor-gray60 {
+  color: $ms-color-gray60;
+}
+@mixin ms-fontColor-gray50 {
+  color: $ms-color-gray50;
+}
+@mixin ms-fontColor-gray40 {
+  color: $ms-color-gray40;
+}
+@mixin ms-fontColor-gray30 {
+  color: $ms-color-gray30;
+}
+@mixin ms-fontColor-gray20 {
+  color: $ms-color-gray20;
+}
+@mixin ms-fontColor-gray10 {
+  color: $ms-color-gray10;
+}
 @mixin ms-fontColor-white {
   color: $ms-color-white;
-}
-
-// Brand and accent colors
-@mixin ms-fontColor-yellow {
-  color: $ms-color-yellow;
-}
-
-@mixin ms-fontColor-yellowLight {
-  color: $ms-color-yellowLight;
-}
-
-@mixin ms-fontColor-orange {
-  color: $ms-color-orange;
-}
-
-@mixin ms-fontColor-orangeLight {
-  color: $ms-color-orangeLight;
-}
-
-@mixin ms-fontColor-orangeLighter {
-  color: $ms-color-orangeLighter;
-}
-
-@mixin ms-fontColor-redDark {
-  color: $ms-color-redDark;
-}
-
-@mixin ms-fontColor-red {
-  color: $ms-color-red;
-}
-
-@mixin ms-fontColor-magentaDark {
-  color: $ms-color-magentaDark;
-}
-
-@mixin ms-fontColor-magenta {
-  color: $ms-color-magenta;
-}
-
-@mixin ms-fontColor-magentaLight {
-  color: $ms-color-magentaLight;
-}
-
-@mixin ms-fontColor-purpleDark {
-  color: $ms-color-purpleDark;
-}
-
-@mixin ms-fontColor-purple {
-  color: $ms-color-purple;
-}
-
-@mixin ms-fontColor-purpleLight {
-  color: $ms-color-purpleLight;
-}
-
-@mixin ms-fontColor-blueDark {
-  color: $ms-color-blueDark;
-}
-
-@mixin ms-fontColor-blueMid {
-  color: $ms-color-blueMid;
-}
-
-@mixin ms-fontColor-blue {
-  color: $ms-color-blue;
-}
-
-@mixin ms-fontColor-blueLight {
-  color: $ms-color-blueLight;
-}
-
-@mixin ms-fontColor-tealDark {
-  color: $ms-color-tealDark;
-}
-
-@mixin ms-fontColor-teal {
-  color: $ms-color-teal;
-}
-
-@mixin ms-fontColor-tealLight {
-  color: $ms-color-tealLight;
-}
-
-@mixin ms-fontColor-greenDark {
-  color: $ms-color-greenDark;
-}
-
-@mixin ms-fontColor-green {
-  color: $ms-color-green;
-}
-
-@mixin ms-fontColor-greenLight {
-  color: $ms-color-greenLight;
-}
-
-// Message colors
-@mixin ms-fontColor-info {
-  color: $ms-color-info;
-}
-
-@mixin ms-fontColor-success {
-  color: $ms-color-success;
-}
-
-@mixin ms-fontColor-alert { // @todo: Deprecated: Use ms-fontColor-severeWarning
-  color: $ms-color-alert;
-}
-
-@mixin ms-fontColor-warning {
-  color: $ms-color-warning;
-}
-
-@mixin ms-fontColor-severeWarning {
-  color: $ms-color-severeWarning;
-}
-
-@mixin ms-fontColor-error {
-  color: $ms-color-error;
 }

--- a/src/sass/variables/_Color.Variables.MDL2.scss
+++ b/src/sass/variables/_Color.Variables.MDL2.scss
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+// Theme
+$ms-color-themeDarker:     #004578 !default;
+$ms-color-themeDark:       #005a9e !default;
+$ms-color-themeDarkAlt:    #106ebe !default;
+$ms-color-themePrimary:    #0078d4 !default;
+$ms-color-themeSecondary:  #2b88d8 !default;
+$ms-color-themeTertiary:   #71afe5 !default;
+$ms-color-themeLight:      #c7e0f4 !default;
+$ms-color-themeLighter:    #deecf9 !default;
+$ms-color-themeLighterAlt: #eff6fc !default;
+
+// Neutral
+$ms-color-black:                 #000000 !default;
+$ms-color-neutralDark:           #212121 !default;
+$ms-color-neutralPrimary:        #333333 !default;
+$ms-color-neutralPrimaryAlt:     #3C3C3C !default;
+$ms-color-neutralSecondary:      #666666 !default;
+$ms-color-neutralSecondaryAlt:   #767676 !default;
+$ms-color-neutralTertiary:       #a6a6a6 !default;
+$ms-color-neutralTertiaryAlt:    #c8c8c8 !default;
+$ms-color-neutralQuaternary:     #d0d0d0 !default;
+$ms-color-neutralQuaternaryAlt:  #dadada !default;
+$ms-color-neutralLight:          #eaeaea !default;
+$ms-color-neutralLighter:        #f4f4f4 !default;
+$ms-color-neutralLighterAlt:     #f8f8f8 !default;
+$ms-color-white:                 #ffffff !default;
+
+// Accent
+$ms-color-yellow:        #ffb900 !default;
+$ms-color-yellowLight:   #fff100 !default;
+$ms-color-orange:        #d83b01 !default;
+$ms-color-orangeLight:   #ea4300 !default;
+$ms-color-orangeLighter: #ff8c00 !default;
+$ms-color-redDark:       #a80000 !default;
+$ms-color-red:           #e81123 !default;
+$ms-color-magentaDark:   #5c005c !default;
+$ms-color-magenta:       #b4009e !default;
+$ms-color-magentaLight:  #e3008c !default;
+$ms-color-purpleDark:    #32145a !default;
+$ms-color-purple:        #5c2d91 !default;
+$ms-color-purpleLight:   #b4a0ff !default;
+$ms-color-blueDark:      #002050 !default;
+$ms-color-blueMid:       #00188f !default;
+$ms-color-blue:          #0078d7 !default;
+$ms-color-blueLight:     #00bcf2 !default;
+$ms-color-tealDark:      #004b50 !default;
+$ms-color-teal:          #008272 !default;
+$ms-color-tealLight:     #00b294 !default;
+$ms-color-greenDark:     #004b1c !default;
+$ms-color-green:         #107c10 !default;
+$ms-color-greenLight:    #bad80a !default;
+
+// Message
+$ms-color-info:              $ms-color-neutralSecondaryAlt !default;
+$ms-color-infoBackground:    $ms-color-neutralLighter !default;
+$ms-color-success:           $ms-color-green !default;
+$ms-color-successBackground: #dff6dd !default;
+$ms-color-severeWarning:     $ms-color-orange !default;
+$ms-color-severeWarningBackground: #fed9cc !default;
+$ms-color-alert:             $ms-color-severeWarning !default;   // Deprecated: Use $ms-color-severeWarning
+$ms-color-alertBackground:   $ms-color-severeWarningBackground !default; // Deprecated: Use $ms-color-severeWarningBackground
+$ms-color-warning:           $ms-color-neutralSecondaryAlt !default;
+$ms-color-warningBackground: #fff4ce !default;
+$ms-color-error:             $ms-color-redDark !default;
+$ms-color-errorBackground:   #fde7e9 !default;
+
+// High contrast colors
+$ms-color-contrastBlackDisabled: #00ff00 !default;
+$ms-color-contrastWhiteDisabled: #600000 !default;
+$ms-color-contrastBlackSelected: #1AEBFF !default;
+$ms-color-contrastWhiteSelected: #37006E !default;

--- a/src/sass/variables/_Color.Variables.scss
+++ b/src/sass/variables/_Color.Variables.scss
@@ -28,3 +28,17 @@ $ms-color-gray30: #edebe9 !default;
 $ms-color-gray20: #f3f2f1 !default;
 $ms-color-gray10: #faf9f8 !default;
 $ms-color-white: #ffffff !default;
+
+// Overrides for deprecated MDL2 colors.
+$ms-color-neutralDark: $ms-color-gray190;
+$ms-color-neutralPrimary: $ms-color-gray160;
+$ms-color-neutralPrimaryAlt: $ms-color-gray150;
+$ms-color-neutralSecondary: $ms-color-gray130;
+$ms-color-neutralSecondaryAlt: $ms-color-gray120;
+$ms-color-neutralTertiary: $ms-color-gray90;
+$ms-color-neutralTertiaryAlt: $ms-color-gray60;
+$ms-color-neutralQuaternary: $ms-color-gray50;
+$ms-color-neutralQuaternaryAlt: $ms-color-gray40;
+$ms-color-neutralLight: $ms-color-gray30;
+$ms-color-neutralLighter: $ms-color-gray20;
+$ms-color-neutralLighterAlt: $ms-color-gray10;

--- a/src/sass/variables/_Color.Variables.scss
+++ b/src/sass/variables/_Color.Variables.scss
@@ -1,73 +1,30 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
-// Theme
-$ms-color-themeDarker:     #004578 !default;
-$ms-color-themeDark:       #005a9e !default;
-$ms-color-themeDarkAlt:    #106ebe !default;
-$ms-color-themePrimary:    #0078d4 !default;
-$ms-color-themeSecondary:  #2b88d8 !default;
-$ms-color-themeTertiary:   #71afe5 !default;
-$ms-color-themeLight:      #c7e0f4 !default;
-$ms-color-themeLighter:    #deecf9 !default;
-$ms-color-themeLighterAlt: #eff6fc !default;
+// Deprecated MDL2 color variables.
+@import "./Color.Variables.MDL2";
 
-// Neutral
-$ms-color-black:                 #000000 !default;
-$ms-color-neutralDark:           #212121 !default;
-$ms-color-neutralPrimary:        #333333 !default;
-$ms-color-neutralPrimaryAlt:     #3C3C3C !default;
-$ms-color-neutralSecondary:      #666666 !default;
-$ms-color-neutralSecondaryAlt:   #767676 !default;
-$ms-color-neutralTertiary:       #a6a6a6 !default;
-$ms-color-neutralTertiaryAlt:    #c8c8c8 !default;
-$ms-color-neutralQuaternary:     #d0d0d0 !default;
-$ms-color-neutralQuaternaryAlt:  #dadada !default;
-$ms-color-neutralLight:          #eaeaea !default;
-$ms-color-neutralLighter:        #f4f4f4 !default;
-$ms-color-neutralLighterAlt:     #f8f8f8 !default;
-$ms-color-white:                 #ffffff !default;
-
-// Accent
-$ms-color-yellow:        #ffb900 !default;
-$ms-color-yellowLight:   #fff100 !default;
-$ms-color-orange:        #d83b01 !default;
-$ms-color-orangeLight:   #ea4300 !default;
-$ms-color-orangeLighter: #ff8c00 !default;
-$ms-color-redDark:       #a80000 !default;
-$ms-color-red:           #e81123 !default;
-$ms-color-magentaDark:   #5c005c !default;
-$ms-color-magenta:       #b4009e !default;
-$ms-color-magentaLight:  #e3008c !default;
-$ms-color-purpleDark:    #32145a !default;
-$ms-color-purple:        #5c2d91 !default;
-$ms-color-purpleLight:   #b4a0ff !default;
-$ms-color-blueDark:      #002050 !default;
-$ms-color-blueMid:       #00188f !default;
-$ms-color-blue:          #0078d7 !default;
-$ms-color-blueLight:     #00bcf2 !default;
-$ms-color-tealDark:      #004b50 !default;
-$ms-color-teal:          #008272 !default;
-$ms-color-tealLight:     #00b294 !default;
-$ms-color-greenDark:     #004b1c !default;
-$ms-color-green:         #107c10 !default;
-$ms-color-greenLight:    #bad80a !default;
-
-// Message
-$ms-color-info:              $ms-color-neutralSecondaryAlt !default;
-$ms-color-infoBackground:    $ms-color-neutralLighter !default;
-$ms-color-success:           $ms-color-green !default;
-$ms-color-successBackground: #dff6dd !default;
-$ms-color-severeWarning:     $ms-color-orange !default;
-$ms-color-severeWarningBackground: #fed9cc !default;
-$ms-color-alert:             $ms-color-severeWarning !default;   // Deprecated: Use $ms-color-severeWarning
-$ms-color-alertBackground:   $ms-color-severeWarningBackground !default; // Deprecated: Use $ms-color-severeWarningBackground
-$ms-color-warning:           $ms-color-neutralSecondaryAlt !default;
-$ms-color-warningBackground: #fff4ce !default;
-$ms-color-error:             $ms-color-redDark !default;
-$ms-color-errorBackground:   #fde7e9 !default;
-
-// High contrast colors
-$ms-color-contrastBlackDisabled: #00ff00 !default;
-$ms-color-contrastWhiteDisabled: #600000 !default;
-$ms-color-contrastBlackSelected: #1AEBFF !default;
-$ms-color-contrastWhiteSelected: #37006E !default;
+// Grays.
+$ms-color-black: #000000 !default;
+$ms-color-gray220: #11100f !default;
+$ms-color-gray210: #161514 !default;
+$ms-color-gray200: #1b1a19 !default;
+$ms-color-gray190: #201f1e !default;
+$ms-color-gray180: #252423 !default;
+$ms-color-gray170: #292827 !default;
+$ms-color-gray160: #323130 !default;
+$ms-color-gray150: #3b3a39 !default;
+$ms-color-gray140: #484644 !default;
+$ms-color-gray130: #605e5c !default;
+$ms-color-gray120: #797775 !default;
+$ms-color-gray110: #8a8886 !default;
+$ms-color-gray100: #979593 !default;
+$ms-color-gray90: #a19f9d !default;
+$ms-color-gray80: #b3b0ad !default;
+$ms-color-gray70: #bebbb8 !default;
+$ms-color-gray60: #c8c6c4 !default;
+$ms-color-gray50: #d2d0ce !default;
+$ms-color-gray40: #e1dfdd !default;
+$ms-color-gray30: #edebe9 !default;
+$ms-color-gray20: #f3f2f1 !default;
+$ms-color-gray10: #faf9f8 !default;
+$ms-color-white: #ffffff !default;


### PR DESCRIPTION
Adds the new gray palette for the [Fluent Design System](https://fluent.microsoft.com/) updates that are coming to Fabric. This PR includes new variables, mixins, and color classes.

Existing MDL2 colors have been mapped to their equivalents in the new Fluent palette. For example, NeutralSecondary maps to Gray130. The full mapping can be found in `Color.Variable.scss`.

To maintain backward compatibility, these have been added *in addition* to the current color palettes. Eventually, the old colors will be deprecated and removed. To facilitate this future removal, they have been moved to files named like `Color.Variables.MDL2.scss`.

![image](https://user-images.githubusercontent.com/1382445/37724010-14941142-2ced-11e8-8814-17f38f540c25.png)
