### PR TITLE
NPM: Add Fluent to the version number and tag it separately from 'latest'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "office-ui-fabric-core",
   "author": "Office UI Fabric Team",
-  "version": "9.6.0",
+  "version": "9.6.0-fluent1",
+  "publishConfig": {
+    "tag": "fluent"
+  },
   "description":
     "The front-end framework for building experiences for Office 365.",
   "license": "MIT",


### PR DESCRIPTION
This allows for projects to opt-in to trying Fluent by specifying "fluent" as the version number when installing via NPM.

The version number starts with the latest release the branch is based on, so over time we can expect to see versions increment something like:

9.6.0-fluent1 (First release based on 9.6.0)
9.6.0-fluent2 (Second release based on 9.6.0)
9.7.0-fluent1 (First release based on 9.7.0)
9.7.1-fluent1 (First release based on 9.7.1)
10.0.0-fluent1 (First release based on 10.0.0)