### PR TITLE
Color: Add high contrast mixins and classes

### DIFF
--- a/src/sass/_Color.Background.scss
+++ b/src/sass/_Color.Background.scss
@@ -917,6 +917,24 @@
   @include ms-bgColor-messageErrorBackground;
 }
 
+// High contrast
+.ms-bgColor-contrastBlackDisabled,
+.ms-bgColor-contrastBlackDisabled--hover:hover {
+  @include ms-bgColor-contrastBlackDisabled;
+}
+.ms-bgColor-contrastWhiteDisabled,
+.ms-bgColor-contrastWhiteDisabled--hover:hover {
+  @include ms-bgColor-contrastWhiteDisabled;
+}
+.ms-bgColor-contrastBlackSelected,
+.ms-bgColor-contrastBlackSelected--hover:hover {
+  @include ms-bgColor-contrastBlackSelected;
+}
+.ms-bgColor-contrastWhiteSelected,
+.ms-bgColor-contrastWhiteSelected--hover:hover {
+  @include ms-bgColor-contrastWhiteSelected;
+}
+
 // Communication
 .ms-bgColor-communication90,
 .ms-bgColor-communication90--hover:hover {

--- a/src/sass/_Color.Border.scss
+++ b/src/sass/_Color.Border.scss
@@ -918,6 +918,24 @@
   @include ms-borderColor-messageErrorBackground;
 }
 
+// High contrast
+.ms-borderColor-contrastBlackDisabled,
+.ms-borderColor-contrastBlackDisabled--hover:hover {
+  @include ms-borderColor-contrastBlackDisabled;
+}
+.ms-borderColor-contrastWhiteDisabled,
+.ms-borderColor-contrastWhiteDisabled--hover:hover {
+  @include ms-borderColor-contrastWhiteDisabled;
+}
+.ms-borderColor-contrastBlackSelected,
+.ms-borderColor-contrastBlackSelected--hover:hover {
+  @include ms-borderColor-contrastBlackSelected;
+}
+.ms-borderColor-contrastWhiteSelected,
+.ms-borderColor-contrastWhiteSelected--hover:hover {
+  @include ms-borderColor-contrastWhiteSelected;
+}
+
 // Communication
 .ms-borderColor-communication90,
 .ms-borderColor-communication90--hover:hover {

--- a/src/sass/_Color.Font.scss
+++ b/src/sass/_Color.Font.scss
@@ -918,6 +918,24 @@
   @include ms-fontColor-messageErrorBackground;
 }
 
+// High contrast
+.ms-fontColor-contrastBlackDisabled,
+.ms-fontColor-contrastBlackDisabled--hover:hover {
+  @include ms-fontColor-contrastBlackDisabled;
+}
+.ms-fontColor-contrastWhiteDisabled,
+.ms-fontColor-contrastWhiteDisabled--hover:hover {
+  @include ms-fontColor-contrastWhiteDisabled;
+}
+.ms-fontColor-contrastBlackSelected,
+.ms-fontColor-contrastBlackSelected--hover:hover {
+  @include ms-fontColor-contrastBlackSelected;
+}
+.ms-fontColor-contrastWhiteSelected,
+.ms-fontColor-contrastWhiteSelected--hover:hover {
+  @include ms-fontColor-contrastWhiteSelected;
+}
+
 // Communication
 .ms-fontColor-communication90,
 .ms-fontColor-communication90--hover:hover {

--- a/src/sass/mixins/_Color.Background.Mixins.scss
+++ b/src/sass/mixins/_Color.Background.Mixins.scss
@@ -690,6 +690,20 @@
   background-color: $ms-color-messageErrorBackground;
 }
 
+// High contrast
+@mixin ms-bgColor-contrastBlackDisabled {
+  background-color: $ms-color-contrastBlackDisabled;
+}
+@mixin ms-bgColor-contrastWhiteDisabled {
+  background-color: $ms-color-contrastWhiteDisabled;
+}
+@mixin ms-bgColor-contrastBlackSelected {
+  background-color: $ms-color-contrastBlackSelected;
+}
+@mixin ms-bgColor-contrastWhiteSelected {
+  background-color: $ms-color-contrastWhiteSelected;
+}
+
 // Communication
 @mixin ms-bgColor-communication90 {
   background-color: $ms-color-communication90;

--- a/src/sass/mixins/_Color.Border.Mixins.scss
+++ b/src/sass/mixins/_Color.Border.Mixins.scss
@@ -690,6 +690,20 @@
   border-color: $ms-color-messageErrorBackground;
 }
 
+// High contrast
+@mixin ms-borderColor-contrastBlackDisabled {
+  border-color: $ms-color-contrastBlackDisabled;
+}
+@mixin ms-borderColor-contrastWhiteDisabled {
+  border-color: $ms-color-contrastWhiteDisabled;
+}
+@mixin ms-borderColor-contrastBlackSelected {
+  border-color: $ms-color-contrastBlackSelected;
+}
+@mixin ms-borderColor-contrastWhiteSelected {
+  border-color: $ms-color-contrastWhiteSelected;
+}
+
 // Communication
 @mixin ms-borderColor-communication90 {
   border-color: $ms-color-communication90;

--- a/src/sass/mixins/_Color.Font.Mixins.scss
+++ b/src/sass/mixins/_Color.Font.Mixins.scss
@@ -690,6 +690,20 @@
   color: $ms-color-messageErrorBackground;
 }
 
+// High contrast
+@mixin ms-fontColor-contrastBlackDisabled {
+  color: $ms-color-contrastBlackDisabled;
+}
+@mixin ms-fontColor-contrastWhiteDisabled {
+  color: $ms-color-contrastWhiteDisabled;
+}
+@mixin ms-fontColor-contrastBlackSelected {
+  color: $ms-color-contrastBlackSelected;
+}
+@mixin ms-fontColor-contrastWhiteSelected {
+  color: $ms-color-contrastWhiteSelected;
+}
+
 // Communication
 @mixin ms-fontColor-communication90 {
   color: $ms-color-communication90;


### PR DESCRIPTION
Adds mixins and classes for the high contrast color palette. While these are unlikely to be used on their own (they are primarily used as variables within high-contrast media queries) it's good for consistency to have them. It also means we can use Fabric classes in the documentation when showing color palettes.