### PR TITLE
Color: Deprecate message colors

### DIFF
--- a/src/sass/_Color.Background.scss
+++ b/src/sass/_Color.Background.scss
@@ -883,40 +883,6 @@
   @include ms-bgColor-pink10;
 }
 
-// Message
-.ms-bgColor-messageInfo,
-.ms-bgColor-messageInfo--hover:hover {
-  @include ms-bgColor-messageInfo;
-}
-.ms-bgColor-messageInfoBackground,
-.ms-bgColor-messageInfoBackground--hover:hover {
-  @include ms-bgColor-messageInfoBackground;
-}
-.ms-bgColor-messageSuccess,
-.ms-bgColor-messageSuccess--hover:hover {
-  @include ms-bgColor-messageSuccess;
-}
-.ms-bgColor-messageSuccessBackground,
-.ms-bgColor-messageSuccessBackground--hover:hover {
-  @include ms-bgColor-messageSuccessBackground;
-}
-.ms-bgColor-messageSevereWarning,
-.ms-bgColor-messageSevereWarning--hover:hover {
-  @include ms-bgColor-messageSevereWarning;
-}
-.ms-bgColor-messageSevereWarningBackground,
-.ms-bgColor-messageSevereWarningBackground--hover:hover {
-  @include ms-bgColor-messageSevereWarningBackground;
-}
-.ms-bgColor-messageError,
-.ms-bgColor-messageError--hover:hover {
-  @include ms-bgColor-messageError;
-}
-.ms-bgColor-messageErrorBackground,
-.ms-bgColor-messageErrorBackground--hover:hover {
-  @include ms-bgColor-messageErrorBackground;
-}
-
 // High contrast
 .ms-bgColor-contrastBlackDisabled,
 .ms-bgColor-contrastBlackDisabled--hover:hover {

--- a/src/sass/_Color.Border.scss
+++ b/src/sass/_Color.Border.scss
@@ -884,40 +884,6 @@
   @include ms-borderColor-pink10;
 }
 
-// Message
-.ms-borderColor-messageInfo,
-.ms-borderColor-messageInfo--hover:hover {
-  @include ms-borderColor-messageInfo;
-}
-.ms-borderColor-messageInfoBackground,
-.ms-borderColor-messageInfoBackground--hover:hover {
-  @include ms-borderColor-messageInfoBackground;
-}
-.ms-borderColor-messageSuccess,
-.ms-borderColor-messageSuccess--hover:hover {
-  @include ms-borderColor-messageSuccess;
-}
-.ms-borderColor-messageSuccessBackground,
-.ms-borderColor-messageSuccessBackground--hover:hover {
-  @include ms-borderColor-messageSuccessBackground;
-}
-.ms-borderColor-messageSevereWarning,
-.ms-borderColor-messageSevereWarning--hover:hover {
-  @include ms-borderColor-messageSevereWarning;
-}
-.ms-borderColor-messageSevereWarningBackground,
-.ms-borderColor-messageSevereWarningBackground--hover:hover {
-  @include ms-borderColor-messageSevereWarningBackground;
-}
-.ms-borderColor-messageError,
-.ms-borderColor-messageError--hover:hover {
-  @include ms-borderColor-messageError;
-}
-.ms-borderColor-messageErrorBackground,
-.ms-borderColor-messageErrorBackground--hover:hover {
-  @include ms-borderColor-messageErrorBackground;
-}
-
 // High contrast
 .ms-borderColor-contrastBlackDisabled,
 .ms-borderColor-contrastBlackDisabled--hover:hover {

--- a/src/sass/_Color.Font.scss
+++ b/src/sass/_Color.Font.scss
@@ -884,40 +884,6 @@
   @include ms-fontColor-pink10;
 }
 
-// Message
-.ms-fontColor-messageInfo,
-.ms-fontColor-messageInfo--hover:hover {
-  @include ms-fontColor-messageInfo;
-}
-.ms-fontColor-messageInfoBackground,
-.ms-fontColor-messageInfoBackground--hover:hover {
-  @include ms-fontColor-messageInfoBackground;
-}
-.ms-fontColor-messageSuccess,
-.ms-fontColor-messageSuccess--hover:hover {
-  @include ms-fontColor-messageSuccess;
-}
-.ms-fontColor-messageSuccessBackground,
-.ms-fontColor-messageSuccessBackground--hover:hover {
-  @include ms-fontColor-messageSuccessBackground;
-}
-.ms-fontColor-messageSevereWarning,
-.ms-fontColor-messageSevereWarning--hover:hover {
-  @include ms-fontColor-messageSevereWarning;
-}
-.ms-fontColor-messageSevereWarningBackground,
-.ms-fontColor-messageSevereWarningBackground--hover:hover {
-  @include ms-fontColor-messageSevereWarningBackground;
-}
-.ms-fontColor-messageError,
-.ms-fontColor-messageError--hover:hover {
-  @include ms-fontColor-messageError;
-}
-.ms-fontColor-messageErrorBackground,
-.ms-fontColor-messageErrorBackground--hover:hover {
-  @include ms-fontColor-messageErrorBackground;
-}
-
 // High contrast
 .ms-fontColor-contrastBlackDisabled,
 .ms-fontColor-contrastBlackDisabled--hover:hover {

--- a/src/sass/_Color.MDL2.scss
+++ b/src/sass/_Color.MDL2.scss
@@ -1,796 +1,634 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
+//== Theme colors
 //
-// Office UI Fabric
-// --------------------------------------------------
-// Fabric Core Color Mixins
 
-//== Background colors
-//
-// Theme colors
+// Background
 .ms-bgColor-themeDark,
 .ms-bgColor-themeDark--hover:hover {
   @include ms-bgColor-themeDark;
 }
-
 .ms-bgColor-themeDarkAlt,
 .ms-bgColor-themeDarkAlt--hover:hover {
   @include ms-bgColor-themeDarkAlt;
 }
-
 .ms-bgColor-themeDarker,
 .ms-bgColor-themeDarker--hover:hover {
   @include ms-bgColor-themeDarker;
 }
-
 .ms-bgColor-themePrimary,
 .ms-bgColor-themePrimary--hover:hover {
   @include ms-bgColor-themePrimary;
 }
-
 .ms-bgColor-themeSecondary,
 .ms-bgColor-themeSecondary--hover:hover {
   @include ms-bgColor-themeSecondary;
 }
-
 .ms-bgColor-themeTertiary,
 .ms-bgColor-themeTertiary--hover:hover {
   @include ms-bgColor-themeTertiary;
 }
-
 .ms-bgColor-themeLight,
 .ms-bgColor-themeLight--hover:hover {
   @include ms-bgColor-themeLight;
 }
-
 .ms-bgColor-themeLighter,
 .ms-bgColor-themeLighter--hover:hover {
   @include ms-bgColor-themeLighter;
 }
-
 .ms-bgColor-themeLighterAlt,
 .ms-bgColor-themeLighterAlt--hover:hover {
   @include ms-bgColor-themeLighterAlt;
 }
 
-// Neutral colors
-.ms-bgColor-black,
-.ms-bgColor-black--hover:hover {
-  @include ms-bgColor-black;
-}
-
-.ms-bgColor-neutralDark,
-.ms-bgColor-neutralDark--hover:hover {
-  @include ms-bgColor-neutralDark;
-}
-
-.ms-bgColor-neutralPrimary,
-.ms-bgColor-neutralPrimary--hover:hover {
-  @include ms-bgColor-neutralPrimary;
-}
-
-.ms-bgColor-neutralPrimaryAlt, 
-.ms-bgColor-neutralPrimaryAlt--hover:hover {
-  @include ms-bgColor-neutralPrimaryAlt;
-}
-
-.ms-bgColor-neutralSecondary, 
-.ms-bgColor-neutralSecondary--hover:hover {
-  @include ms-bgColor-neutralSecondary;
-}
-
-.ms-bgColor-neutralSecondaryAlt,
-.ms-bgColor-neutralSecondaryAlt--hover:hover {
-  @include ms-bgColor-neutralSecondaryAlt;
-}
-
-.ms-bgColor-neutralTertiary,
-.ms-bgColor-neutralTertiary--hover:hover {
-  @include ms-bgColor-neutralTertiary;
-}
-
-.ms-bgColor-neutralTertiaryAlt,
-.ms-bgColor-neutralTertiaryAlt--hover:hover {
-  @include ms-bgColor-neutralTertiaryAlt;
-}
-
-.ms-bgColor-neutralQuaternary,
-.ms-bgColor-neutralQuaternary--hover:hover {
-  @include ms-bgColor-neutralQuaternary;
-}
-
-.ms-bgColor-neutralQuaternaryAlt,
-.ms-bgColor-neutralQuaternaryAlt--hover:hover {
-  @include ms-bgColor-neutralQuaternaryAlt;
-}
-
-.ms-bgColor-neutralLight,
-.ms-bgColor-neutralLight--hover:hover {
-  @include ms-bgColor-neutralLight;
-}
-
-.ms-bgColor-neutralLighter,
-.ms-bgColor-neutralLighter--hover:hover {
-  @include ms-bgColor-neutralLighter;
-}
-
-.ms-bgColor-neutralLighterAlt,
-.ms-bgColor-neutralLighterAlt--hover:hover {
-  @include ms-bgColor-neutralLighterAlt;
-}
-
-.ms-bgColor-white,
-.ms-bgColor-white--hover:hover {
-  @include ms-bgColor-white;
-}
-
-
-// Brand and accent colors
-.ms-bgColor-yellow,
-.ms-bgColor-yellow--hover:hover {
-  @include ms-bgColor-yellow;
-}
-
-.ms-bgColor-yellowLight,
-.ms-bgColor-yellowLight--hover:hover {
-  @include ms-bgColor-yellowLight;
-}
-
-.ms-bgColor-orange,
-.ms-bgColor-orange--hover:hover {
-  @include ms-bgColor-orange;
-}
-
-.ms-bgColor-orangeLight,
-.ms-bgColor-orangeLight--hover:hover {
-  @include ms-bgColor-orangeLight;
-}
-
-.ms-bgColor-orangeLighter,
-.ms-bgColor-orangeLighter--hover:hover {
-  @include ms-bgColor-orangeLighter;
-}
-
-.ms-bgColor-redDark,
-.ms-bgColor-redDark--hover:hover {
-  @include ms-bgColor-redDark;
-}
-
-.ms-bgColor-red,
-.ms-bgColor-red--hover:hover {
-  @include ms-bgColor-red;
-}
-
-.ms-bgColor-magentaDark,
-.ms-bgColor-magentaDark--hover:hover {
-  @include ms-bgColor-magentaDark;
-}
-
-.ms-bgColor-magenta,
-.ms-bgColor-magenta--hover:hover {
-  @include ms-bgColor-magenta;
-}
-
-.ms-bgColor-magentaLight,
-.ms-bgColor-magentaLight--hover:hover {
-  @include ms-bgColor-magentaLight;
-}
-
-.ms-bgColor-purpleDark,
-.ms-bgColor-purpleDark--hover:hover {
-  @include ms-bgColor-purpleDark;
-}
-
-.ms-bgColor-purple,
-.ms-bgColor-purple--hover:hover {
-  @include ms-bgColor-purple;
-}
-
-.ms-bgColor-purpleLight,
-.ms-bgColor-purpleLight--hover:hover {
-  @include ms-bgColor-purpleLight;
-}
-
-.ms-bgColor-blueDark,
-.ms-bgColor-blueDark--hover:hover {
-  @include ms-bgColor-blueDark;
-}
-
-.ms-bgColor-blueMid,
-.ms-bgColor-blueMid--hover:hover {
-  @include ms-bgColor-blueMid;
-}
-
-.ms-bgColor-blue,
-.ms-bgColor-blue--hover:hover {
-  @include ms-bgColor-blue;
-}
-
-.ms-bgColor-blueLight,
-.ms-bgColor-blueLight--hover:hover {
-  @include ms-bgColor-blueLight;
-}
-
-.ms-bgColor-tealDark,
-.ms-bgColor-tealDark--hover:hover {
-  @include ms-bgColor-tealDark;
-}
-
-.ms-bgColor-teal,
-.ms-bgColor-teal--hover:hover {
-  @include ms-bgColor-teal;
-}
-
-.ms-bgColor-tealLight,
-.ms-bgColor-tealLight--hover:hover {
-  @include ms-bgColor-tealLight;
-}
-
-.ms-bgColor-greenDark,
-.ms-bgColor-greenDark--hover:hover {
-  @include ms-bgColor-greenDark;
-}
-
-.ms-bgColor-green,
-.ms-bgColor-green--hover:hover {
-  @include ms-bgColor-green;
-}
-
-.ms-bgColor-greenLight,
-.ms-bgColor-greenLight--hover:hover {
-  @include ms-bgColor-greenLight;
-}
-
-// Message colors
-.ms-bgColor-info,
-.ms-bgColor-info--hover:hover {
-  @include ms-bgColor-info;
-}
-
-.ms-bgColor-success,
-.ms-bgColor-success--hover:hover {
-  @include ms-bgColor-success;
-}
-
-.ms-bgColor-severeWarning,
-.ms-bgColor-severeWarning--hover:hover {
-  @include ms-bgColor-severeWarning;
-}
-
-.ms-bgColor-warning,
-.ms-bgColor-warning--hover:hover {
-  @include ms-bgColor-warning;
-}
-
-.ms-bgColor-error,
-.ms-bgColor-error--hover:hover {
-  @include ms-bgColor-error;
-}
-
-
-//== Border colors
-//
-
-// Theme colors
+// Border
 .ms-borderColor-themeDark,
 .ms-borderColor-themeDark--hover:hover {
   @include ms-borderColor-themeDark;
 }
-
 .ms-borderColor-themeDarkAlt,
 .ms-borderColor-themeDarkAlt--hover:hover {
   @include ms-borderColor-themeDarkAlt;
 }
-
 .ms-borderColor-themeDarker,
 .ms-borderColor-themeDarker--hover:hover {
   @include ms-borderColor-themeDarker;
 }
-
 .ms-borderColor-themePrimary,
 .ms-borderColor-themePrimary--hover:hover {
   @include ms-borderColor-themePrimary;
 }
-
 .ms-borderColor-themeSecondary,
 .ms-borderColor-themeSecondary--hover:hover {
   @include ms-borderColor-themeSecondary;
 }
-
 .ms-borderColor-themeTertiary,
 .ms-borderColor-themeTertiary--hover:hover {
   @include ms-borderColor-themeTertiary;
 }
-
 .ms-borderColor-themeLight,
 .ms-borderColor-themeLight--hover:hover {
   @include ms-borderColor-themeLight;
 }
-
 .ms-borderColor-themeLighter,
 .ms-borderColor-themeLighter--hover:hover {
   @include ms-borderColor-themeLighter;
 }
-
 .ms-borderColor-themeLighterAlt,
 .ms-borderColor-themeLighterAlt--hover:hover {
   @include ms-borderColor-themeLighterAlt;
 }
 
-
-// Neutral colors
-.ms-borderColor-black,
-.ms-borderColor-black--hover:hover {
-  @include ms-borderColor-black;
-}
-
-.ms-borderColor-neutralDark,
-.ms-borderColor-neutralDark--hover:hover {
-  @include ms-borderColor-neutralDark;
-}
-
-.ms-borderColor-neutralPrimary,
-.ms-borderColor-neutralPrimary--hover:hover {
-  @include ms-borderColor-neutralPrimary;
-}
-
-.ms-borderColor-neutralPrimaryAlt, 
-.ms-borderColor-neutralPrimaryAlt--hover:hover {
-  @include ms-borderColor-neutralPrimaryAlt;
-}
-
-.ms-borderColor-neutralSecondary, 
-.ms-borderColor-neutralSecondary--hover:hover {
-  @include ms-borderColor-neutralSecondary;
-}
-
-.ms-borderColor-neutralSecondaryAlt,
-.ms-borderColor-neutralSecondaryAlt--hover:hover {
-  @include ms-borderColor-neutralSecondaryAlt;
-}
-
-.ms-borderColor-neutralTertiary,
-.ms-borderColor-neutralTertiary--hover:hover {
-  @include ms-borderColor-neutralTertiary;
-}
-
-.ms-borderColor-neutralTertiaryAlt,
-.ms-borderColor-neutralTertiaryAlt--hover:hover {
-  @include ms-borderColor-neutralTertiaryAlt;
-}
-
-.ms-borderColor-neutralQuaternary,
-.ms-borderColor-neutralQuaternary--hover:hover {
-  @include ms-borderColor-neutralQuaternary;
-}
-
-.ms-borderColor-neutralQuaternaryAlt,
-.ms-borderColor-neutralQuaternaryAlt--hover:hover {
-  @include ms-borderColor-neutralQuaternaryAlt;
-}
-
-.ms-borderColor-neutralLight,
-.ms-borderColor-neutralLight--hover:hover {
-  @include ms-borderColor-neutralLight;
-}
-
-.ms-borderColor-neutralLighter,
-.ms-borderColor-neutralLighter--hover:hover {
-  @include ms-borderColor-neutralLighter;
-}
-
-.ms-borderColor-neutralLighterAlt,
-.ms-borderColor-neutralLighterAlt--hover:hover {
-  @include ms-borderColor-neutralLighterAlt;
-}
-
-.ms-borderColor-white,
-.ms-borderColor-white--hover:hover {
-  @include ms-borderColor-white;
-}
-
-// Brand and accent colors
-.ms-borderColor-yellow,
-.ms-borderColor-yellow--hover:hover {
-  @include ms-borderColor-yellow;
-}
-
-.ms-borderColor-yellowLight,
-.ms-borderColor-yellowLight--hover:hover {
-  @include ms-borderColor-yellowLight;
-}
-
-.ms-borderColor-orange,
-.ms-borderColor-orange--hover:hover {
-  @include ms-borderColor-orange;
-}
-
-.ms-borderColor-orangeLight,
-.ms-borderColor-orangeLight--hover:hover {
-  @include ms-borderColor-orangeLight;
-}
-
-.ms-borderColor-orangeLighter,
-.ms-borderColor-orangeLighter--hover:hover {
-  @include ms-borderColor-orangeLighter;
-}
-
-.ms-borderColor-redDark,
-.ms-borderColor-redDark--hover:hover {
-  @include ms-borderColor-redDark;
-}
-
-.ms-borderColor-red,
-.ms-borderColor-red--hover:hover {
-  @include ms-borderColor-red;
-}
-
-.ms-borderColor-magentaDark,
-.ms-borderColor-magentaDark--hover:hover {
-  @include ms-borderColor-magentaDark;
-}
-
-.ms-borderColor-magenta,
-.ms-borderColor-magenta--hover:hover {
-  @include ms-borderColor-magenta;
-}
-
-.ms-borderColor-magentaLight,
-.ms-borderColor-magentaLight--hover:hover {
-  @include ms-borderColor-magentaLight;
-}
-
-.ms-borderColor-purpleDark,
-.ms-borderColor-purpleDark--hover:hover {
-  @include ms-borderColor-purpleDark;
-}
-
-.ms-borderColor-purple,
-.ms-borderColor-purple--hover:hover {
-  @include ms-borderColor-purple;
-}
-
-.ms-borderColor-purpleLight,
-.ms-borderColor-purpleLight--hover:hover {
-  @include ms-borderColor-purpleLight;
-}
-
-.ms-borderColor-blueDark,
-.ms-borderColor-blueDark--hover:hover {
-  @include ms-borderColor-blueDark;
-}
-
-.ms-borderColor-blueMid,
-.ms-borderColor-blueMid--hover:hover {
-  @include ms-borderColor-blueMid;
-}
-
-.ms-borderColor-blue,
-.ms-borderColor-blue--hover:hover {
-  @include ms-borderColor-blue;
-}
-
-.ms-borderColor-blueLight,
-.ms-borderColor-blueLight--hover:hover {
-  @include ms-borderColor-blueLight;
-}
-
-.ms-borderColor-tealDark,
-.ms-borderColor-tealDark--hover:hover {
-  @include ms-borderColor-tealDark;
-}
-
-.ms-borderColor-teal,
-.ms-borderColor-teal--hover:hover {
-  @include ms-borderColor-teal;
-}
-
-.ms-borderColor-tealLight,
-.ms-borderColor-tealLight--hover:hover {
-  @include ms-borderColor-tealLight;
-}
-
-.ms-borderColor-greenDark,
-.ms-borderColor-greenDark--hover:hover {
-  @include ms-borderColor-greenDark;
-}
-
-.ms-borderColor-green,
-.ms-borderColor-green--hover:hover {
-  @include ms-borderColor-green;
-}
-
-.ms-borderColor-greenLight,
-.ms-borderColor-greenLight--hover:hover {
-  @include ms-borderColor-greenLight;
-}
-
-// Message colors
-@mixin ms-fontColor-info {
-  color: $ms-color-info;
-}
-
-@mixin ms-fontColor-success {
-  color: $ms-color-success;
-}
-
-@mixin ms-fontColor-alert {
-  color: $ms-color-alert;
-}
-
-@mixin ms-fontColor-warning {
-  color: $ms-color-warning;
-}
-
-@mixin ms-fontColor-severeWarning {
-  color: $ms-color-severeWarning;
-}
-
-@mixin ms-fontColor-error {
-  color: $ms-color-error;
-}
-
-
-// Theme colors
+// Font
 .ms-fontColor-themeDarker,
 .ms-fontColor-themeDarker--hover:hover {
   @include ms-fontColor-themeDarker;
 }
-
 .ms-fontColor-themeDark,
 .ms-fontColor-themeDark--hover:hover {
   @include ms-fontColor-themeDark;
 }
-
 .ms-fontColor-themeDarkAlt,
 .ms-fontColor-themeDarkAlt--hover:hover {
   @include ms-fontColor-themeDarkAlt;
 }
-
 .ms-fontColor-themePrimary,
 .ms-fontColor-themePrimary--hover:hover {
   @include ms-fontColor-themePrimary;
 }
-
 .ms-fontColor-themeSecondary,
 .ms-fontColor-themeSecondary--hover:hover {
   @include ms-fontColor-themeSecondary;
 }
-
 .ms-fontColor-themeTertiary,
 .ms-fontColor-themeTertiary--hover:hover {
   @include ms-fontColor-themeTertiary;
 }
-
 .ms-fontColor-themeLight,
 .ms-fontColor-themeLight--hover:hover {
   @include ms-fontColor-themeLight;
 }
-
 .ms-fontColor-themeLighter,
 .ms-fontColor-themeLighter--hover:hover {
   @include ms-fontColor-themeLighter;
 }
-
 .ms-fontColor-themeLighterAlt,
 .ms-fontColor-themeLighterAlt--hover:hover {
   @include ms-fontColor-themeLighterAlt;
 }
 
+//== Neutral colors
+//
 
-// Neutral colors
+// Background
+.ms-bgColor-black,
+.ms-bgColor-black--hover:hover {
+  @include ms-bgColor-black;
+}
+.ms-bgColor-neutralDark,
+.ms-bgColor-neutralDark--hover:hover {
+  @include ms-bgColor-neutralDark;
+}
+.ms-bgColor-neutralPrimary,
+.ms-bgColor-neutralPrimary--hover:hover {
+  @include ms-bgColor-neutralPrimary;
+}
+.ms-bgColor-neutralPrimaryAlt,
+.ms-bgColor-neutralPrimaryAlt--hover:hover {
+  @include ms-bgColor-neutralPrimaryAlt;
+}
+.ms-bgColor-neutralSecondary,
+.ms-bgColor-neutralSecondary--hover:hover {
+  @include ms-bgColor-neutralSecondary;
+}
+.ms-bgColor-neutralSecondaryAlt,
+.ms-bgColor-neutralSecondaryAlt--hover:hover {
+  @include ms-bgColor-neutralSecondaryAlt;
+}
+.ms-bgColor-neutralTertiary,
+.ms-bgColor-neutralTertiary--hover:hover {
+  @include ms-bgColor-neutralTertiary;
+}
+.ms-bgColor-neutralTertiaryAlt,
+.ms-bgColor-neutralTertiaryAlt--hover:hover {
+  @include ms-bgColor-neutralTertiaryAlt;
+}
+.ms-bgColor-neutralQuaternary,
+.ms-bgColor-neutralQuaternary--hover:hover {
+  @include ms-bgColor-neutralQuaternary;
+}
+.ms-bgColor-neutralQuaternaryAlt,
+.ms-bgColor-neutralQuaternaryAlt--hover:hover {
+  @include ms-bgColor-neutralQuaternaryAlt;
+}
+.ms-bgColor-neutralLight,
+.ms-bgColor-neutralLight--hover:hover {
+  @include ms-bgColor-neutralLight;
+}
+.ms-bgColor-neutralLighter,
+.ms-bgColor-neutralLighter--hover:hover {
+  @include ms-bgColor-neutralLighter;
+}
+.ms-bgColor-neutralLighterAlt,
+.ms-bgColor-neutralLighterAlt--hover:hover {
+  @include ms-bgColor-neutralLighterAlt;
+}
+.ms-bgColor-white,
+.ms-bgColor-white--hover:hover {
+  @include ms-bgColor-white;
+}
+
+// Border
+.ms-borderColor-black,
+.ms-borderColor-black--hover:hover {
+  @include ms-borderColor-black;
+}
+.ms-borderColor-neutralDark,
+.ms-borderColor-neutralDark--hover:hover {
+  @include ms-borderColor-neutralDark;
+}
+.ms-borderColor-neutralPrimary,
+.ms-borderColor-neutralPrimary--hover:hover {
+  @include ms-borderColor-neutralPrimary;
+}
+.ms-borderColor-neutralPrimaryAlt,
+.ms-borderColor-neutralPrimaryAlt--hover:hover {
+  @include ms-borderColor-neutralPrimaryAlt;
+}
+.ms-borderColor-neutralSecondary,
+.ms-borderColor-neutralSecondary--hover:hover {
+  @include ms-borderColor-neutralSecondary;
+}
+.ms-borderColor-neutralSecondaryAlt,
+.ms-borderColor-neutralSecondaryAlt--hover:hover {
+  @include ms-borderColor-neutralSecondaryAlt;
+}
+.ms-borderColor-neutralTertiary,
+.ms-borderColor-neutralTertiary--hover:hover {
+  @include ms-borderColor-neutralTertiary;
+}
+.ms-borderColor-neutralTertiaryAlt,
+.ms-borderColor-neutralTertiaryAlt--hover:hover {
+  @include ms-borderColor-neutralTertiaryAlt;
+}
+.ms-borderColor-neutralQuaternary,
+.ms-borderColor-neutralQuaternary--hover:hover {
+  @include ms-borderColor-neutralQuaternary;
+}
+.ms-borderColor-neutralQuaternaryAlt,
+.ms-borderColor-neutralQuaternaryAlt--hover:hover {
+  @include ms-borderColor-neutralQuaternaryAlt;
+}
+.ms-borderColor-neutralLight,
+.ms-borderColor-neutralLight--hover:hover {
+  @include ms-borderColor-neutralLight;
+}
+.ms-borderColor-neutralLighter,
+.ms-borderColor-neutralLighter--hover:hover {
+  @include ms-borderColor-neutralLighter;
+}
+.ms-borderColor-neutralLighterAlt,
+.ms-borderColor-neutralLighterAlt--hover:hover {
+  @include ms-borderColor-neutralLighterAlt;
+}
+.ms-borderColor-white,
+.ms-borderColor-white--hover:hover {
+  @include ms-borderColor-white;
+}
+
+// Font
 .ms-fontColor-black,
 .ms-fontColor-black--hover:hover {
   @include ms-fontColor-black;
 }
-
 .ms-fontColor-neutralDark,
 .ms-fontColor-neutralDark--hover:hover {
   @include ms-fontColor-neutralDark;
 }
-
 .ms-fontColor-neutralPrimary,
 .ms-fontColor-neutralPrimary--hover:hover {
   @include ms-fontColor-neutralPrimary;
 }
-
-.ms-fontColor-neutralPrimaryAlt, 
+.ms-fontColor-neutralPrimaryAlt,
 .ms-fontColor-neutralPrimaryAlt--hover:hover {
   @include ms-fontColor-neutralPrimaryAlt;
 }
-
-.ms-fontColor-neutralSecondary, 
+.ms-fontColor-neutralSecondary,
 .ms-fontColor-neutralSecondary--hover:hover {
   @include ms-fontColor-neutralSecondary;
 }
-
 .ms-fontColor-neutralSecondaryAlt,
 .ms-fontColor-neutralSecondaryAlt--hover:hover {
   @include ms-fontColor-neutralSecondaryAlt;
 }
-
 .ms-fontColor-neutralTertiary,
 .ms-fontColor-neutralTertiary--hover:hover {
   @include ms-fontColor-neutralTertiary;
 }
-
 .ms-fontColor-neutralTertiaryAlt,
 .ms-fontColor-neutralTertiaryAlt--hover:hover {
   @include ms-fontColor-neutralTertiaryAlt;
 }
-
 .ms-fontColor-neutralQuaternary,
 .ms-fontColor-neutralQuaternary--hover:hover {
   @include ms-fontColor-neutralQuaternary;
 }
-
 .ms-fontColor-neutralQuaternaryAlt,
 .ms-fontColor-neutralQuaternaryAlt--hover:hover {
   @include ms-fontColor-neutralQuaternaryAlt;
 }
-
 .ms-fontColor-neutralLight,
 .ms-fontColor-neutralLight--hover:hover {
   @include ms-fontColor-neutralLight;
 }
-
 .ms-fontColor-neutralLighter,
 .ms-fontColor-neutralLighter--hover:hover {
   @include ms-fontColor-neutralLighter;
 }
-
 .ms-fontColor-neutralLighterAlt,
 .ms-fontColor-neutralLighterAlt--hover:hover {
   @include ms-fontColor-neutralLighterAlt;
 }
-
 .ms-fontColor-white,
 .ms-fontColor-white--hover:hover {
   @include ms-fontColor-white;
 }
 
-// Brand and accent colors
+//== Brand and accent colors
+//
+
+// Background
+.ms-bgColor-yellow,
+.ms-bgColor-yellow--hover:hover {
+  @include ms-bgColor-yellow;
+}
+.ms-bgColor-yellowLight,
+.ms-bgColor-yellowLight--hover:hover {
+  @include ms-bgColor-yellowLight;
+}
+.ms-bgColor-orange,
+.ms-bgColor-orange--hover:hover {
+  @include ms-bgColor-orange;
+}
+.ms-bgColor-orangeLight,
+.ms-bgColor-orangeLight--hover:hover {
+  @include ms-bgColor-orangeLight;
+}
+.ms-bgColor-orangeLighter,
+.ms-bgColor-orangeLighter--hover:hover {
+  @include ms-bgColor-orangeLighter;
+}
+.ms-bgColor-redDark,
+.ms-bgColor-redDark--hover:hover {
+  @include ms-bgColor-redDark;
+}
+.ms-bgColor-red,
+.ms-bgColor-red--hover:hover {
+  @include ms-bgColor-red;
+}
+.ms-bgColor-magentaDark,
+.ms-bgColor-magentaDark--hover:hover {
+  @include ms-bgColor-magentaDark;
+}
+.ms-bgColor-magenta,
+.ms-bgColor-magenta--hover:hover {
+  @include ms-bgColor-magenta;
+}
+.ms-bgColor-magentaLight,
+.ms-bgColor-magentaLight--hover:hover {
+  @include ms-bgColor-magentaLight;
+}
+.ms-bgColor-purpleDark,
+.ms-bgColor-purpleDark--hover:hover {
+  @include ms-bgColor-purpleDark;
+}
+.ms-bgColor-purple,
+.ms-bgColor-purple--hover:hover {
+  @include ms-bgColor-purple;
+}
+.ms-bgColor-purpleLight,
+.ms-bgColor-purpleLight--hover:hover {
+  @include ms-bgColor-purpleLight;
+}
+.ms-bgColor-blueDark,
+.ms-bgColor-blueDark--hover:hover {
+  @include ms-bgColor-blueDark;
+}
+.ms-bgColor-blueMid,
+.ms-bgColor-blueMid--hover:hover {
+  @include ms-bgColor-blueMid;
+}
+.ms-bgColor-blue,
+.ms-bgColor-blue--hover:hover {
+  @include ms-bgColor-blue;
+}
+.ms-bgColor-blueLight,
+.ms-bgColor-blueLight--hover:hover {
+  @include ms-bgColor-blueLight;
+}
+.ms-bgColor-tealDark,
+.ms-bgColor-tealDark--hover:hover {
+  @include ms-bgColor-tealDark;
+}
+.ms-bgColor-teal,
+.ms-bgColor-teal--hover:hover {
+  @include ms-bgColor-teal;
+}
+.ms-bgColor-tealLight,
+.ms-bgColor-tealLight--hover:hover {
+  @include ms-bgColor-tealLight;
+}
+.ms-bgColor-greenDark,
+.ms-bgColor-greenDark--hover:hover {
+  @include ms-bgColor-greenDark;
+}
+.ms-bgColor-green,
+.ms-bgColor-green--hover:hover {
+  @include ms-bgColor-green;
+}
+.ms-bgColor-greenLight,
+.ms-bgColor-greenLight--hover:hover {
+  @include ms-bgColor-greenLight;
+}
+
+// Border
+.ms-borderColor-yellow,
+.ms-borderColor-yellow--hover:hover {
+  @include ms-borderColor-yellow;
+}
+.ms-borderColor-yellowLight,
+.ms-borderColor-yellowLight--hover:hover {
+  @include ms-borderColor-yellowLight;
+}
+.ms-borderColor-orange,
+.ms-borderColor-orange--hover:hover {
+  @include ms-borderColor-orange;
+}
+.ms-borderColor-orangeLight,
+.ms-borderColor-orangeLight--hover:hover {
+  @include ms-borderColor-orangeLight;
+}
+.ms-borderColor-orangeLighter,
+.ms-borderColor-orangeLighter--hover:hover {
+  @include ms-borderColor-orangeLighter;
+}
+.ms-borderColor-redDark,
+.ms-borderColor-redDark--hover:hover {
+  @include ms-borderColor-redDark;
+}
+.ms-borderColor-red,
+.ms-borderColor-red--hover:hover {
+  @include ms-borderColor-red;
+}
+.ms-borderColor-magentaDark,
+.ms-borderColor-magentaDark--hover:hover {
+  @include ms-borderColor-magentaDark;
+}
+.ms-borderColor-magenta,
+.ms-borderColor-magenta--hover:hover {
+  @include ms-borderColor-magenta;
+}
+.ms-borderColor-magentaLight,
+.ms-borderColor-magentaLight--hover:hover {
+  @include ms-borderColor-magentaLight;
+}
+.ms-borderColor-purpleDark,
+.ms-borderColor-purpleDark--hover:hover {
+  @include ms-borderColor-purpleDark;
+}
+.ms-borderColor-purple,
+.ms-borderColor-purple--hover:hover {
+  @include ms-borderColor-purple;
+}
+.ms-borderColor-purpleLight,
+.ms-borderColor-purpleLight--hover:hover {
+  @include ms-borderColor-purpleLight;
+}
+.ms-borderColor-blueDark,
+.ms-borderColor-blueDark--hover:hover {
+  @include ms-borderColor-blueDark;
+}
+.ms-borderColor-blueMid,
+.ms-borderColor-blueMid--hover:hover {
+  @include ms-borderColor-blueMid;
+}
+.ms-borderColor-blue,
+.ms-borderColor-blue--hover:hover {
+  @include ms-borderColor-blue;
+}
+.ms-borderColor-blueLight,
+.ms-borderColor-blueLight--hover:hover {
+  @include ms-borderColor-blueLight;
+}
+.ms-borderColor-tealDark,
+.ms-borderColor-tealDark--hover:hover {
+  @include ms-borderColor-tealDark;
+}
+.ms-borderColor-teal,
+.ms-borderColor-teal--hover:hover {
+  @include ms-borderColor-teal;
+}
+.ms-borderColor-tealLight,
+.ms-borderColor-tealLight--hover:hover {
+  @include ms-borderColor-tealLight;
+}
+.ms-borderColor-greenDark,
+.ms-borderColor-greenDark--hover:hover {
+  @include ms-borderColor-greenDark;
+}
+.ms-borderColor-green,
+.ms-borderColor-green--hover:hover {
+  @include ms-borderColor-green;
+}
+.ms-borderColor-greenLight,
+.ms-borderColor-greenLight--hover:hover {
+  @include ms-borderColor-greenLight;
+}
+
+// Font
 .ms-fontColor-yellow,
 .ms-fontColor-yellow--hover:hover {
   @include ms-fontColor-yellow;
 }
-
 .ms-fontColor-yellowLight,
 .ms-fontColor-yellowLight--hover:hover {
   @include ms-fontColor-yellowLight;
 }
-
 .ms-fontColor-orange,
 .ms-fontColor-orange--hover:hover {
   @include ms-fontColor-orange;
 }
-
 .ms-fontColor-orangeLight,
 .ms-fontColor-orangeLight--hover:hover {
   @include ms-fontColor-orangeLight;
 }
-
 .ms-fontColor-orangeLighter,
 .ms-fontColor-orangeLighter--hover:hover {
   @include ms-fontColor-orangeLighter;
 }
-
 .ms-fontColor-redDark,
 .ms-fontColor-redDark--hover:hover {
   @include ms-fontColor-redDark;
 }
-
 .ms-fontColor-red,
 .ms-fontColor-red--hover:hover {
   @include ms-fontColor-red;
 }
-
 .ms-fontColor-magentaDark,
 .ms-fontColor-magentaDark--hover:hover {
   @include ms-fontColor-magentaDark;
 }
-
 .ms-fontColor-magenta,
 .ms-fontColor-magenta--hover:hover {
   @include ms-fontColor-magenta;
 }
-
 .ms-fontColor-magentaLight,
 .ms-fontColor-magentaLight--hover:hover {
   @include ms-fontColor-magentaLight;
 }
-
 .ms-fontColor-purpleDark,
 .ms-fontColor-purpleDark--hover:hover {
   @include ms-fontColor-purpleDark;
 }
-
 .ms-fontColor-purple,
 .ms-fontColor-purple--hover:hover {
   @include ms-fontColor-purple;
 }
-
 .ms-fontColor-purpleLight,
 .ms-fontColor-purpleLight--hover:hover {
   @include ms-fontColor-purpleLight;
 }
-
 .ms-fontColor-blueDark,
 .ms-fontColor-blueDark--hover:hover {
   @include ms-fontColor-blueDark;
 }
-
 .ms-fontColor-blueMid,
 .ms-fontColor-blueMid--hover:hover {
   @include ms-fontColor-blueMid;
 }
-
 .ms-fontColor-blue,
 .ms-fontColor-blue--hover:hover {
   @include ms-fontColor-blue;
 }
-
 .ms-fontColor-blueLight,
 .ms-fontColor-blueLight--hover:hover {
   @include ms-fontColor-blueLight;
 }
-
 .ms-fontColor-tealDark,
 .ms-fontColor-tealDark--hover:hover {
   @include ms-fontColor-tealDark;
 }
-
 .ms-fontColor-teal,
 .ms-fontColor-teal--hover:hover {
   @include ms-fontColor-teal;
 }
-
 .ms-fontColor-tealLight,
 .ms-fontColor-tealLight--hover:hover {
   @include ms-fontColor-tealLight;
 }
-
 .ms-fontColor-greenDark,
 .ms-fontColor-greenDark--hover:hover {
   @include ms-fontColor-greenDark;
 }
-
 .ms-fontColor-green,
 .ms-fontColor-green--hover:hover {
   @include ms-fontColor-green;
 }
-
 .ms-fontColor-greenLight,
 .ms-fontColor-greenLight--hover:hover {
   @include ms-fontColor-greenLight;
 }
 
-// Message colors
+//== Message colors
+//
+
+// Background
+.ms-bgColor-info,
+.ms-bgColor-info--hover:hover {
+  @include ms-bgColor-info;
+}
+.ms-bgColor-success,
+.ms-bgColor-success--hover:hover {
+  @include ms-bgColor-success;
+}
+.ms-bgColor-severeWarning,
+.ms-bgColor-severeWarning--hover:hover {
+  @include ms-bgColor-severeWarning;
+}
+.ms-bgColor-warning,
+.ms-bgColor-warning--hover:hover {
+  @include ms-bgColor-warning;
+}
+.ms-bgColor-error,
+.ms-bgColor-error--hover:hover {
+  @include ms-bgColor-error;
+}
+
+// Border
+// Classes were never provided for message color borders.
+
+// Font
 .ms-fontColor-info,
 .ms-fontColor-info--hover:hover {
   @include ms-fontColor-info;
 }
-
 .ms-fontColor-success,
 .ms-fontColor-success--hover:hover {
   @include ms-fontColor-success;
 }
-
-.ms-fontColor-alert, 
-.ms-fontColor-alert--hover:hover {   // Deprecated: Use ms-fontColor-severeWarning
-   @include ms-fontColor-alert;
+.ms-fontColor-alert,
+.ms-fontColor-alert--hover:hover {
+  // Deprecated: Use ms-fontColor-severeWarning
+  @include ms-fontColor-alert;
 }
-
 .ms-fontColor-warning,
 .ms-fontColor-warning--hover:hover {
   @include ms-fontColor-warning;
 }
-
 .ms-fontColor-severeWarning,
 .ms-fontColor-severeWarning--hover:hover {
   @include ms-fontColor-severeWarning;
 }
-
 .ms-fontColor-error,
 .ms-fontColor-error--hover:hover {
   @include ms-fontColor-error;

--- a/src/sass/mixins/_Color.Background.Mixins.scss
+++ b/src/sass/mixins/_Color.Background.Mixins.scss
@@ -664,32 +664,6 @@
   background-color: $ms-color-pink10;
 }
 
-// Message
-@mixin ms-bgColor-messageInfo {
-  background-color: $ms-color-messageInfo;
-}
-@mixin ms-bgColor-messageInfoBackground {
-  background-color: $ms-color-messageInfoBackground;
-}
-@mixin ms-bgColor-messageSuccess {
-  background-color: $ms-color-messageSuccess;
-}
-@mixin ms-bgColor-messageSuccessBackground {
-  background-color: $ms-color-messageSuccessBackground;
-}
-@mixin ms-bgColor-messageSevereWarning {
-  background-color: $ms-color-messageSevereWarning;
-}
-@mixin ms-bgColor-messageSevereWarningBackground {
-  background-color: $ms-color-messageSevereWarningBackground;
-}
-@mixin ms-bgColor-messageError {
-  background-color: $ms-color-messageError;
-}
-@mixin ms-bgColor-messageErrorBackground {
-  background-color: $ms-color-messageErrorBackground;
-}
-
 // High contrast
 @mixin ms-bgColor-contrastBlackDisabled {
   background-color: $ms-color-contrastBlackDisabled;

--- a/src/sass/mixins/_Color.Border.Mixins.scss
+++ b/src/sass/mixins/_Color.Border.Mixins.scss
@@ -664,32 +664,6 @@
   border-color: $ms-color-pink10;
 }
 
-// Message
-@mixin ms-borderColor-messageInfo {
-  border-color: $ms-color-messageInfo;
-}
-@mixin ms-borderColor-messageInfoBackground {
-  border-color: $ms-color-messageInfoBackground;
-}
-@mixin ms-borderColor-messageSuccess {
-  border-color: $ms-color-messageSuccess;
-}
-@mixin ms-borderColor-messageSuccessBackground {
-  border-color: $ms-color-messageSuccessBackground;
-}
-@mixin ms-borderColor-messageSevereWarning {
-  border-color: $ms-color-messageSevereWarning;
-}
-@mixin ms-borderColor-messageSevereWarningBackground {
-  border-color: $ms-color-messageSevereWarningBackground;
-}
-@mixin ms-borderColor-messageError {
-  border-color: $ms-color-messageError;
-}
-@mixin ms-borderColor-messageErrorBackground {
-  border-color: $ms-color-messageErrorBackground;
-}
-
 // High contrast
 @mixin ms-borderColor-contrastBlackDisabled {
   border-color: $ms-color-contrastBlackDisabled;

--- a/src/sass/mixins/_Color.Font.Mixins.scss
+++ b/src/sass/mixins/_Color.Font.Mixins.scss
@@ -664,32 +664,6 @@
   color: $ms-color-pink10;
 }
 
-// Message
-@mixin ms-fontColor-messageInfo {
-  color: $ms-color-messageInfo;
-}
-@mixin ms-fontColor-messageInfoBackground {
-  color: $ms-color-messageInfoBackground;
-}
-@mixin ms-fontColor-messageSuccess {
-  color: $ms-color-messageSuccess;
-}
-@mixin ms-fontColor-messageSuccessBackground {
-  color: $ms-color-messageSuccessBackground;
-}
-@mixin ms-fontColor-messageSevereWarning {
-  color: $ms-color-messageSevereWarning;
-}
-@mixin ms-fontColor-messageSevereWarningBackground {
-  color: $ms-color-messageSevereWarningBackground;
-}
-@mixin ms-fontColor-messageError {
-  color: $ms-color-messageError;
-}
-@mixin ms-fontColor-messageErrorBackground {
-  color: $ms-color-messageErrorBackground;
-}
-
 // High contrast
 @mixin ms-fontColor-contrastBlackDisabled {
   color: $ms-color-contrastBlackDisabled;

--- a/src/sass/mixins/_Color.Mixins.MDL2.scss
+++ b/src/sass/mixins/_Color.Mixins.MDL2.scss
@@ -1,609 +1,475 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
+//== Theme colors
 //
-// Office UI Fabric
-// --------------------------------------------------
-// Fabric Core Color Mixins
 
-//== Background colors
-//
-// Theme colors
+// Background
 @mixin ms-bgColor-themeDark {
   background-color: $ms-color-themeDark;
 }
-
 @mixin ms-bgColor-themeDarkAlt {
   background-color: $ms-color-themeDarkAlt;
 }
-
 @mixin ms-bgColor-themeDarker {
   background-color: $ms-color-themeDarker;
 }
-
 @mixin ms-bgColor-themePrimary {
   background-color: $ms-color-themePrimary;
 }
-
 @mixin ms-bgColor-themeSecondary {
   background-color: $ms-color-themeSecondary;
 }
-
 @mixin ms-bgColor-themeTertiary {
   background-color: $ms-color-themeTertiary;
 }
-
 @mixin ms-bgColor-themeLight {
   background-color: $ms-color-themeLight;
 }
-
 @mixin ms-bgColor-themeLighter {
   background-color: $ms-color-themeLighter;
 }
-
 @mixin ms-bgColor-themeLighterAlt {
   background-color: $ms-color-themeLighterAlt;
 }
 
-// Neutral colors
-@mixin ms-bgColor-neutralDark {
-  background-color: $ms-color-neutralDark;
-}
-
-@mixin ms-bgColor-neutralPrimary {
-  background-color: $ms-color-neutralPrimary;
-}
-
-@mixin ms-bgColor-neutralPrimaryAlt {
-  background-color: $ms-color-neutralPrimaryAlt;
-}
-
-@mixin ms-bgColor-neutralSecondary {
-  background-color: $ms-color-neutralSecondary;
-}
-
-@mixin ms-bgColor-neutralSecondaryAlt {
-  background-color: $ms-color-neutralSecondaryAlt;
-}
-
-@mixin ms-bgColor-neutralTertiary {
-  background-color: $ms-color-neutralTertiary;
-}
-
-@mixin ms-bgColor-neutralTertiaryAlt {
-  background-color: $ms-color-neutralTertiaryAlt;
-}
-
-@mixin ms-bgColor-neutralQuaternary {
-  background-color: $ms-color-neutralQuaternary;
-}
-
-@mixin ms-bgColor-neutralQuaternaryAlt {
-  background-color: $ms-color-neutralQuaternaryAlt;
-}
-
-@mixin ms-bgColor-neutralLight {
-  background-color: $ms-color-neutralLight;
-}
-
-@mixin ms-bgColor-neutralLighter {
-  background-color: $ms-color-neutralLighter;
-}
-
-@mixin ms-bgColor-neutralLighterAlt {
-  background-color: $ms-color-neutralLighterAlt;
-}
-
-// Brand and accent colors
-@mixin ms-bgColor-yellow {
-  background-color: $ms-color-yellow;
-}
-
-@mixin ms-bgColor-yellowLight {
-  background-color: $ms-color-yellowLight;
-}
-
-@mixin ms-bgColor-orange {
-  background-color: $ms-color-orange;
-}
-
-@mixin ms-bgColor-orangeLight {
-  background-color: $ms-color-orangeLight;
-}
-
-@mixin ms-bgColor-orangeLighter {
-  background-color: $ms-color-orangeLighter;
-}
-
-@mixin ms-bgColor-redDark {
-  background-color: $ms-color-redDark;
-}
-
-@mixin ms-bgColor-red {
-  background-color: $ms-color-red;
-}
-
-@mixin ms-bgColor-magentaDark {
-  background-color: $ms-color-magentaDark;
-}
-
-@mixin ms-bgColor-magenta {
-  background-color: $ms-color-magenta;
-}
-
-@mixin ms-bgColor-magentaLight {
-  background-color: $ms-color-magentaLight;
-}
-
-@mixin ms-bgColor-purpleDark {
-  background-color: $ms-color-purpleDark;
-}
-
-@mixin ms-bgColor-purple {
-  background-color: $ms-color-purple;
-}
-
-@mixin ms-bgColor-purpleLight {
-  background-color: $ms-color-purpleLight;
-}
-
-@mixin ms-bgColor-blueDark {
-  background-color: $ms-color-blueDark;
-}
-
-@mixin ms-bgColor-blueMid {
-  background-color: $ms-color-blueMid;
-}
-
-@mixin ms-bgColor-blue {
-  background-color: $ms-color-blue;
-}
-
-@mixin ms-bgColor-blueLight {
-  background-color: $ms-color-blueLight;
-}
-
-@mixin ms-bgColor-tealDark {
-  background-color: $ms-color-tealDark;
-}
-
-@mixin ms-bgColor-teal {
-  background-color: $ms-color-teal;
-}
-
-@mixin ms-bgColor-tealLight {
-  background-color: $ms-color-tealLight;
-}
-
-@mixin ms-bgColor-greenDark {
-  background-color: $ms-color-greenDark;
-}
-
-@mixin ms-bgColor-green {
-  background-color: $ms-color-green;
-}
-
-@mixin ms-bgColor-greenLight {
-  background-color: $ms-color-greenLight;
-}
-
-// Message colors
-@mixin ms-bgColor-info {
-  background-color: $ms-color-infoBackground;
-}
-
-@mixin ms-bgColor-success {
-  background-color: $ms-color-successBackground;
-}
-
-@mixin ms-bgColor-severeWarning {
-  background-color: $ms-color-severeWarningBackground;
-}
-
-@mixin ms-bgColor-warning {
-  background-color: $ms-color-warningBackground;
-}
-
-@mixin ms-bgColor-error {
-  background-color: $ms-color-errorBackground;
-}
-
-//== Border colors
-//
-
-// Theme colors
+// Border
 @mixin ms-borderColor-themeDark {
   border-color: $ms-color-themeDark;
 }
-
 @mixin ms-borderColor-themeDarkAlt {
   border-color: $ms-color-themeDarkAlt;
 }
-
 @mixin ms-borderColor-themeDarker {
   border-color: $ms-color-themeDarker;
 }
-
 @mixin ms-borderColor-themePrimary {
   border-color: $ms-color-themePrimary;
 }
-
 @mixin ms-borderColor-themeSecondary {
   border-color: $ms-color-themeSecondary;
 }
-
 @mixin ms-borderColor-themeTertiary {
   border-color: $ms-color-themeTertiary;
 }
-
 @mixin ms-borderColor-themeLight {
   border-color: $ms-color-themeLight;
 }
-
 @mixin ms-borderColor-themeLighter {
   border-color: $ms-color-themeLighter;
 }
-
 @mixin ms-borderColor-themeLighterAlt {
   border-color: $ms-color-themeLighterAlt;
 }
 
-// Neutral colors
-@mixin ms-borderColor-neutralDark {
-  border-color: $ms-color-neutralDark;
-}
-
-@mixin ms-borderColor-neutralPrimary {
-  border-color: $ms-color-neutralPrimary;
-}
-
-@mixin ms-borderColor-neutralPrimaryAlt {
-  border-color: $ms-color-neutralPrimaryAlt;
-}
-
-@mixin ms-borderColor-neutralSecondary {
-  border-color: $ms-color-neutralSecondary;
-}
-
-@mixin ms-borderColor-neutralSecondaryAlt {
-  border-color: $ms-color-neutralSecondaryAlt;
-}
-
-@mixin ms-borderColor-neutralTertiary {
-  border-color: $ms-color-neutralTertiary;
-}
-
-@mixin ms-borderColor-neutralTertiaryAlt {
-  border-color: $ms-color-neutralTertiaryAlt;
-}
-
-@mixin ms-borderColor-neutralQuaternary {
-  border-color: $ms-color-neutralQuaternary;
-}
-
-@mixin ms-borderColor-neutralQuaternaryAlt {
-  border-color: $ms-color-neutralQuaternaryAlt;
-}
-
-@mixin ms-borderColor-neutralLight {
-  border-color: $ms-color-neutralLight;
-}
-
-@mixin ms-borderColor-neutralLighter {
-  border-color: $ms-color-neutralLighter;
-}
-
-@mixin ms-borderColor-neutralLighterAlt {
-  border-color: $ms-color-neutralLighterAlt;
-}
-
-// Brand and accent colors
-@mixin ms-borderColor-yellow {
-  border-color: $ms-color-yellow;
-}
-
-@mixin ms-borderColor-yellowLight {
-  border-color: $ms-color-yellowLight;
-}
-
-@mixin ms-borderColor-orange {
-  border-color: $ms-color-orange;
-}
-
-@mixin ms-borderColor-orangeLight {
-  border-color: $ms-color-orangeLight;
-}
-
-@mixin ms-borderColor-orangeLighter {
-  border-color: $ms-color-orangeLighter;
-}
-
-@mixin ms-borderColor-redDark {
-  border-color: $ms-color-redDark;
-}
-
-@mixin ms-borderColor-red {
-  border-color: $ms-color-red;
-}
-
-@mixin ms-borderColor-magentaDark {
-  border-color: $ms-color-magentaDark;
-}
-
-@mixin ms-borderColor-magenta {
-  border-color: $ms-color-magenta;
-}
-
-@mixin ms-borderColor-magentaLight {
-  border-color: $ms-color-magentaLight;
-}
-
-@mixin ms-borderColor-purpleDark {
-  border-color: $ms-color-purpleDark;
-}
-
-@mixin ms-borderColor-purple {
-  border-color: $ms-color-purple;
-}
-
-@mixin ms-borderColor-purpleLight {
-  border-color: $ms-color-purpleLight;
-}
-
-@mixin ms-borderColor-blueDark {
-  border-color: $ms-color-blueDark;
-}
-
-@mixin ms-borderColor-blueMid {
-  border-color: $ms-color-blueMid;
-}
-
-@mixin ms-borderColor-blue {
-  border-color: $ms-color-blue;
-}
-
-@mixin ms-borderColor-blueLight {
-  border-color: $ms-color-blueLight;
-}
-
-@mixin ms-borderColor-tealDark {
-  border-color: $ms-color-tealDark;
-}
-
-@mixin ms-borderColor-teal {
-  border-color: $ms-color-teal;
-}
-
-@mixin ms-borderColor-tealLight {
-  border-color: $ms-color-tealLight;
-}
-
-@mixin ms-borderColor-greenDark {
-  border-color: $ms-color-greenDark;
-}
-
-@mixin ms-borderColor-green {
-  border-color: $ms-color-green;
-}
-
-@mixin ms-borderColor-greenLight {
-  border-color: $ms-color-greenLight;
-}
-
-// Message colors
-@mixin ms-borderColor-info {
-  border-color: $ms-color-info;
-}
-
-@mixin ms-borderColor-success {
-  border-color: $ms-color-success;
-}
-
-@mixin ms-borderColor-alert {
-  border-color: $ms-color-alert;
-}
-
-@mixin ms-borderColor-error {
-  border-color: $ms-color-error;
-}
-
-
-// Theme colors
+// Font
 @mixin ms-fontColor-themeDarker {
   color: $ms-color-themeDarker;
 }
-
 @mixin ms-fontColor-themeDark {
   color: $ms-color-themeDark;
 }
-
 @mixin ms-fontColor-themeDarkAlt {
   color: $ms-color-themeDarkAlt;
 }
-
 @mixin ms-fontColor-themePrimary {
   color: $ms-color-themePrimary;
 }
-
 @mixin ms-fontColor-themeSecondary {
   color: $ms-color-themeSecondary;
 }
-
 @mixin ms-fontColor-themeTertiary {
   color: $ms-color-themeTertiary;
 }
-
 @mixin ms-fontColor-themeLight {
   color: $ms-color-themeLight;
 }
-
 @mixin ms-fontColor-themeLighter {
   color: $ms-color-themeLighter;
 }
-
 @mixin ms-fontColor-themeLighterAlt {
   color: $ms-color-themeLighterAlt;
 }
 
+//== Neutral colors
+//
 
-// Neutral colors
+// Background
+@mixin ms-bgColor-neutralDark {
+  background-color: $ms-color-neutralDark;
+}
+@mixin ms-bgColor-neutralPrimary {
+  background-color: $ms-color-neutralPrimary;
+}
+@mixin ms-bgColor-neutralPrimaryAlt {
+  background-color: $ms-color-neutralPrimaryAlt;
+}
+@mixin ms-bgColor-neutralSecondary {
+  background-color: $ms-color-neutralSecondary;
+}
+@mixin ms-bgColor-neutralSecondaryAlt {
+  background-color: $ms-color-neutralSecondaryAlt;
+}
+@mixin ms-bgColor-neutralTertiary {
+  background-color: $ms-color-neutralTertiary;
+}
+@mixin ms-bgColor-neutralTertiaryAlt {
+  background-color: $ms-color-neutralTertiaryAlt;
+}
+@mixin ms-bgColor-neutralQuaternary {
+  background-color: $ms-color-neutralQuaternary;
+}
+@mixin ms-bgColor-neutralQuaternaryAlt {
+  background-color: $ms-color-neutralQuaternaryAlt;
+}
+@mixin ms-bgColor-neutralLight {
+  background-color: $ms-color-neutralLight;
+}
+@mixin ms-bgColor-neutralLighter {
+  background-color: $ms-color-neutralLighter;
+}
+@mixin ms-bgColor-neutralLighterAlt {
+  background-color: $ms-color-neutralLighterAlt;
+}
+
+// Border
+@mixin ms-borderColor-neutralDark {
+  border-color: $ms-color-neutralDark;
+}
+@mixin ms-borderColor-neutralPrimary {
+  border-color: $ms-color-neutralPrimary;
+}
+@mixin ms-borderColor-neutralPrimaryAlt {
+  border-color: $ms-color-neutralPrimaryAlt;
+}
+@mixin ms-borderColor-neutralSecondary {
+  border-color: $ms-color-neutralSecondary;
+}
+@mixin ms-borderColor-neutralSecondaryAlt {
+  border-color: $ms-color-neutralSecondaryAlt;
+}
+@mixin ms-borderColor-neutralTertiary {
+  border-color: $ms-color-neutralTertiary;
+}
+@mixin ms-borderColor-neutralTertiaryAlt {
+  border-color: $ms-color-neutralTertiaryAlt;
+}
+@mixin ms-borderColor-neutralQuaternary {
+  border-color: $ms-color-neutralQuaternary;
+}
+@mixin ms-borderColor-neutralQuaternaryAlt {
+  border-color: $ms-color-neutralQuaternaryAlt;
+}
+@mixin ms-borderColor-neutralLight {
+  border-color: $ms-color-neutralLight;
+}
+@mixin ms-borderColor-neutralLighter {
+  border-color: $ms-color-neutralLighter;
+}
+@mixin ms-borderColor-neutralLighterAlt {
+  border-color: $ms-color-neutralLighterAlt;
+}
+
+// Font
 @mixin ms-fontColor-neutralDark {
   color: $ms-color-neutralDark;
 }
-
 @mixin ms-fontColor-neutralPrimary {
   color: $ms-color-neutralPrimary;
 }
-
 @mixin ms-fontColor-neutralPrimaryAlt {
   color: $ms-color-neutralPrimaryAlt;
 }
-
 @mixin ms-fontColor-neutralSecondary {
- color: $ms-color-neutralSecondary;
+  color: $ms-color-neutralSecondary;
 }
-
 @mixin ms-fontColor-neutralSecondaryAlt {
   color: $ms-color-neutralSecondaryAlt;
 }
-
 @mixin ms-fontColor-neutralTertiary {
   color: $ms-color-neutralTertiary;
 }
-
 @mixin ms-fontColor-neutralTertiaryAlt {
   color: $ms-color-neutralTertiaryAlt;
 }
-
 @mixin ms-fontColor-neutralQuaternary {
   color: $ms-color-neutralQuaternary;
 }
-
 @mixin ms-fontColor-neutralQuaternaryAlt {
   color: $ms-color-neutralQuaternaryAlt;
 }
-
 @mixin ms-fontColor-neutralLight {
   color: $ms-color-neutralLight;
 }
-
 @mixin ms-fontColor-neutralLighter {
   color: $ms-color-neutralLighter;
 }
-
 @mixin ms-fontColor-neutralLighterAlt {
   color: $ms-color-neutralLighterAlt;
 }
 
-// Brand and accent colors
+//== Brand and accent colors
+//
+
+// Background
+@mixin ms-bgColor-yellow {
+  background-color: $ms-color-yellow;
+}
+@mixin ms-bgColor-yellowLight {
+  background-color: $ms-color-yellowLight;
+}
+@mixin ms-bgColor-orange {
+  background-color: $ms-color-orange;
+}
+@mixin ms-bgColor-orangeLight {
+  background-color: $ms-color-orangeLight;
+}
+@mixin ms-bgColor-orangeLighter {
+  background-color: $ms-color-orangeLighter;
+}
+@mixin ms-bgColor-redDark {
+  background-color: $ms-color-redDark;
+}
+@mixin ms-bgColor-red {
+  background-color: $ms-color-red;
+}
+@mixin ms-bgColor-magentaDark {
+  background-color: $ms-color-magentaDark;
+}
+@mixin ms-bgColor-magenta {
+  background-color: $ms-color-magenta;
+}
+@mixin ms-bgColor-magentaLight {
+  background-color: $ms-color-magentaLight;
+}
+@mixin ms-bgColor-purpleDark {
+  background-color: $ms-color-purpleDark;
+}
+@mixin ms-bgColor-purple {
+  background-color: $ms-color-purple;
+}
+@mixin ms-bgColor-purpleLight {
+  background-color: $ms-color-purpleLight;
+}
+@mixin ms-bgColor-blueDark {
+  background-color: $ms-color-blueDark;
+}
+@mixin ms-bgColor-blueMid {
+  background-color: $ms-color-blueMid;
+}
+@mixin ms-bgColor-blue {
+  background-color: $ms-color-blue;
+}
+@mixin ms-bgColor-blueLight {
+  background-color: $ms-color-blueLight;
+}
+@mixin ms-bgColor-tealDark {
+  background-color: $ms-color-tealDark;
+}
+@mixin ms-bgColor-teal {
+  background-color: $ms-color-teal;
+}
+@mixin ms-bgColor-tealLight {
+  background-color: $ms-color-tealLight;
+}
+@mixin ms-bgColor-greenDark {
+  background-color: $ms-color-greenDark;
+}
+@mixin ms-bgColor-green {
+  background-color: $ms-color-green;
+}
+@mixin ms-bgColor-greenLight {
+  background-color: $ms-color-greenLight;
+}
+
+// Border
+@mixin ms-borderColor-yellow {
+  border-color: $ms-color-yellow;
+}
+@mixin ms-borderColor-yellowLight {
+  border-color: $ms-color-yellowLight;
+}
+@mixin ms-borderColor-orange {
+  border-color: $ms-color-orange;
+}
+@mixin ms-borderColor-orangeLight {
+  border-color: $ms-color-orangeLight;
+}
+@mixin ms-borderColor-orangeLighter {
+  border-color: $ms-color-orangeLighter;
+}
+@mixin ms-borderColor-redDark {
+  border-color: $ms-color-redDark;
+}
+@mixin ms-borderColor-red {
+  border-color: $ms-color-red;
+}
+@mixin ms-borderColor-magentaDark {
+  border-color: $ms-color-magentaDark;
+}
+@mixin ms-borderColor-magenta {
+  border-color: $ms-color-magenta;
+}
+@mixin ms-borderColor-magentaLight {
+  border-color: $ms-color-magentaLight;
+}
+@mixin ms-borderColor-purpleDark {
+  border-color: $ms-color-purpleDark;
+}
+@mixin ms-borderColor-purple {
+  border-color: $ms-color-purple;
+}
+@mixin ms-borderColor-purpleLight {
+  border-color: $ms-color-purpleLight;
+}
+@mixin ms-borderColor-blueDark {
+  border-color: $ms-color-blueDark;
+}
+@mixin ms-borderColor-blueMid {
+  border-color: $ms-color-blueMid;
+}
+@mixin ms-borderColor-blue {
+  border-color: $ms-color-blue;
+}
+@mixin ms-borderColor-blueLight {
+  border-color: $ms-color-blueLight;
+}
+@mixin ms-borderColor-tealDark {
+  border-color: $ms-color-tealDark;
+}
+@mixin ms-borderColor-teal {
+  border-color: $ms-color-teal;
+}
+@mixin ms-borderColor-tealLight {
+  border-color: $ms-color-tealLight;
+}
+@mixin ms-borderColor-greenDark {
+  border-color: $ms-color-greenDark;
+}
+@mixin ms-borderColor-green {
+  border-color: $ms-color-green;
+}
+@mixin ms-borderColor-greenLight {
+  border-color: $ms-color-greenLight;
+}
+
+// Font
 @mixin ms-fontColor-yellow {
   color: $ms-color-yellow;
 }
-
 @mixin ms-fontColor-yellowLight {
   color: $ms-color-yellowLight;
 }
-
 @mixin ms-fontColor-orange {
   color: $ms-color-orange;
 }
-
 @mixin ms-fontColor-orangeLight {
   color: $ms-color-orangeLight;
 }
-
 @mixin ms-fontColor-orangeLighter {
   color: $ms-color-orangeLighter;
 }
-
 @mixin ms-fontColor-redDark {
   color: $ms-color-redDark;
 }
-
 @mixin ms-fontColor-red {
   color: $ms-color-red;
 }
-
 @mixin ms-fontColor-magentaDark {
   color: $ms-color-magentaDark;
 }
-
 @mixin ms-fontColor-magenta {
   color: $ms-color-magenta;
 }
-
 @mixin ms-fontColor-magentaLight {
   color: $ms-color-magentaLight;
 }
-
 @mixin ms-fontColor-purpleDark {
   color: $ms-color-purpleDark;
 }
-
 @mixin ms-fontColor-purple {
   color: $ms-color-purple;
 }
-
 @mixin ms-fontColor-purpleLight {
   color: $ms-color-purpleLight;
 }
-
 @mixin ms-fontColor-blueDark {
   color: $ms-color-blueDark;
 }
-
 @mixin ms-fontColor-blueMid {
   color: $ms-color-blueMid;
 }
-
 @mixin ms-fontColor-blue {
   color: $ms-color-blue;
 }
-
 @mixin ms-fontColor-blueLight {
   color: $ms-color-blueLight;
 }
-
 @mixin ms-fontColor-tealDark {
   color: $ms-color-tealDark;
 }
-
 @mixin ms-fontColor-teal {
   color: $ms-color-teal;
 }
-
 @mixin ms-fontColor-tealLight {
   color: $ms-color-tealLight;
 }
-
 @mixin ms-fontColor-greenDark {
   color: $ms-color-greenDark;
 }
-
 @mixin ms-fontColor-green {
   color: $ms-color-green;
 }
-
 @mixin ms-fontColor-greenLight {
   color: $ms-color-greenLight;
 }
 
-// Message colors
+//== Message colors
+//
+
+// Background
+@mixin ms-bgColor-info {
+  background-color: $ms-color-infoBackground;
+}
+@mixin ms-bgColor-success {
+  background-color: $ms-color-successBackground;
+}
+@mixin ms-bgColor-severeWarning {
+  background-color: $ms-color-severeWarningBackground;
+}
+@mixin ms-bgColor-warning {
+  background-color: $ms-color-warningBackground;
+}
+@mixin ms-bgColor-error {
+  background-color: $ms-color-errorBackground;
+}
+
+// Border
+@mixin ms-borderColor-info {
+  border-color: $ms-color-info;
+}
+@mixin ms-borderColor-success {
+  border-color: $ms-color-success;
+}
+@mixin ms-borderColor-alert {
+  border-color: $ms-color-alert;
+}
+@mixin ms-borderColor-error {
+  border-color: $ms-color-error;
+}
+
+// Font
 @mixin ms-fontColor-info {
   color: $ms-color-info;
 }
-
 @mixin ms-fontColor-success {
   color: $ms-color-success;
 }
-
 @mixin ms-fontColor-warning {
   color: $ms-color-warning;
 }
-
 @mixin ms-fontColor-severeWarning {
   color: $ms-color-severeWarning;
 }
-
 @mixin ms-fontColor-error {
   color: $ms-color-error;
 }

--- a/src/sass/mixins/_Color.Mixins.MDL2.scss
+++ b/src/sass/mixins/_Color.Mixins.MDL2.scss
@@ -464,6 +464,10 @@
 @mixin ms-fontColor-success {
   color: $ms-color-success;
 }
+@mixin ms-fontColor-alert {
+  // @todo: Deprecated: Use ms-fontColor-severeWarning
+  color: $ms-color-alert;
+}
 @mixin ms-fontColor-warning {
   color: $ms-color-warning;
 }

--- a/src/sass/variables/_Color.Variables.MDL2.scss
+++ b/src/sass/variables/_Color.Variables.MDL2.scss
@@ -53,15 +53,15 @@ $ms-color-green: $ms-color-green120 !default;
 $ms-color-greenLight: $ms-color-yellowGreen50 !default;
 
 // Message
-$ms-color-info: $ms-color-messageInfo !default;
-$ms-color-infoBackground: $ms-color-messageInfoBackground !default;
-$ms-color-success: $ms-color-messageSuccess !default;
-$ms-color-successBackground: $ms-color-messageSuccessBackground !default;
-$ms-color-severeWarning: $ms-color-messageSevereWarning !default;
-$ms-color-severeWarningBackground: $ms-color-messageSevereWarningBackground !default;
-$ms-color-alert: $ms-color-severeWarning !default;
-$ms-color-alertBackground: $ms-color-severeWarningBackground !default;
-$ms-color-warning: $ms-color-messageWarning !default;
-$ms-color-warningBackground: $ms-color-messageWarningBackground !default;
-$ms-color-error: $ms-color-messageError !default;
-$ms-color-errorBackground: $ms-color-messageError !default;
+$ms-color-info: $ms-color-neutralSecondaryAlt !default;
+$ms-color-infoBackground: $ms-color-neutralLighter !default;
+$ms-color-success: $ms-color-green !default;
+$ms-color-successBackground: #dff6dd !default;
+$ms-color-severeWarning: $ms-color-orange !default;
+$ms-color-severeWarningBackground: #fed9cc !default;
+$ms-color-alert: $ms-color-severeWarning !default; // Deprecated: Use $ms-color-severeWarning
+$ms-color-alertBackground: $ms-color-severeWarningBackground !default; // Deprecated: Use $ms-color-severeWarningBackground
+$ms-color-warning: $ms-color-neutralSecondaryAlt !default;
+$ms-color-warningBackground: #fff4ce !default;
+$ms-color-error: $ms-color-redDark !default;
+$ms-color-errorBackground: #fde7e9 !default;

--- a/src/sass/variables/_Color.Variables.scss
+++ b/src/sass/variables/_Color.Variables.scss
@@ -224,18 +224,6 @@ $ms-color-pink30: #ea005e !default;
 $ms-color-pink20: #ee3f86 !default;
 $ms-color-pink10: #edbed3 !default;
 
-// Message
-$ms-color-messageInfo: $ms-color-gray120 !default;
-$ms-color-messageInfoBackground: $ms-color-gray20 !default;
-$ms-color-messageSuccess: $ms-color-green120 !default;
-$ms-color-messageSuccessBackground: #dff6dd !default;
-$ms-color-messageSevereWarning: #d83b01 !default;
-$ms-color-messageSevereWarningBackground: #fed9cc !default;
-$ms-color-messageWarning: $ms-color-gray120 !default;
-$ms-color-messageWarningBackground: #fff4ce !default;
-$ms-color-messageError: $ms-color-red150 !default;
-$ms-color-messageErrorBackground: #fde7e9 !default;
-
 // High contrast
 $ms-color-contrastBlackDisabled: #00ff00 !default;
 $ms-color-contrastWhiteDisabled: #600000 !default;


### PR DESCRIPTION
This PR deprecates the message colors, which are not part of the Fluent design language and won't be included in future versions of Fabric. I've also organized the deprecated/MDL2 files consistently.