### PR TITLE
Directionality: Reduce unnecessary specificity of box shadows

### DIFF
--- a/src/sass/mixins/_Directionality.Mixins.scss
+++ b/src/sass/mixins/_Directionality.Mixins.scss
@@ -296,12 +296,16 @@
 
 // Box-shadow.
 @mixin ms-box-shadow($left, $etc) {
-  @include ms-LTR {
-    box-shadow: $left $etc;
-  }
+  @if $left != 0 {
+    @include ms-LTR {
+      box-shadow: $left $etc;
+    }
 
-  @include ms-RTL {
-    box-shadow: -$left $etc;
+    @include ms-RTL {
+      box-shadow: -$left $etc;
+    }
+  } @else {
+    box-shadow: 0 $etc;
   }
 }
 


### PR DESCRIPTION
Prior to this change, the `ms-box-shadow()` mixin was using the LTR and RTL mixins for all shadows, even those that were identical for both directions.

```
[dir='ltr'] .vertical {
  box-shadow: 0 10px 5px 5px rgba(0, 0, 0, 0.5);
}
[dir='rtl'] .vertical {
  box-shadow: 0 10px 5px 5px rgba(0, 0, 0, 0.5);
}
```

It will now only return a single style, with less specificity, for vertical shadows:
```
.vertical {
  box-shadow: 0 10px 5px 5px rgba(0, 0, 0, 0.5);
}
```