### PR TITLE
Reduce gap between media queries

### DIFF
--- a/src/sass/variables/_Responsive.Variables.scss
+++ b/src/sass/variables/_Responsive.Variables.scss
@@ -1,16 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
-// Minimum widths for each breakpoint
-$ms-screen-min-sm:    320px !default;
-$ms-screen-min-md:    480px !default;
-$ms-screen-min-lg:    640px !default;
-$ms-screen-min-xl:    1024px !default;
-$ms-screen-min-xxl:   1366px !default;
-$ms-screen-min-xxxl:  1920px !default;
+// Minimum widths for each breakpoint.
+$ms-screen-min-sm: 320px !default;
+$ms-screen-min-md: 480px !default;
+$ms-screen-min-lg: 640px !default;
+$ms-screen-min-xl: 1024px !default;
+$ms-screen-min-xxl: 1366px !default;
+$ms-screen-min-xxxl: 1920px !default;
 
-// Maximum widths for each breakpoint
-$ms-screen-max-sm:  ($ms-screen-min-md - 1);
-$ms-screen-max-md:  ($ms-screen-min-lg - 1);
-$ms-screen-max-lg:  ($ms-screen-min-xl - 1);
-$ms-screen-max-xl:  ($ms-screen-min-xxl - 1);
-$ms-screen-max-xxl: ($ms-screen-min-xxxl - 1);
+// Maximum widths for each breakpoint. These are set to values like 479.99999px to prevent an issue where a browser's
+// width may not be a whole pixel value, creating the potential for multiple media queries to apply simultaneously.
+// See: http://damienclarke.me/code/posts/those-1px-gaps-between-media-queries-can-be-a-problem
+$ms-screen-max-sm: ($ms-screen-min-md - 0.00001);
+$ms-screen-max-md: ($ms-screen-min-lg - 0.00001);
+$ms-screen-max-lg: ($ms-screen-min-xl - 0.00001);
+$ms-screen-max-xl: ($ms-screen-min-xxl - 0.00001);
+$ms-screen-max-xxl: ($ms-screen-min-xxxl - 0.00001);


### PR DESCRIPTION
Fixes #1132 by reducing the gap between media queries from `1px` to `0.00001px`. This prevents an issue where a browser width that is between two breakpoints (e.g. 479.5px) would apply two media queries, which were intended to be exclusive.