### PR TITLE
Fluent: Add black and white to MDL2

### DIFF
--- a/src/sass/mixins/_Color.Mixins.MDL2.scss
+++ b/src/sass/mixins/_Color.Mixins.MDL2.scss
@@ -94,6 +94,9 @@
 //
 
 // Background
+@mixin ms-bgColor-black {
+  background-color: $ms-color-black;
+}
 @mixin ms-bgColor-neutralDark {
   background-color: $ms-color-neutralDark;
 }
@@ -130,8 +133,14 @@
 @mixin ms-bgColor-neutralLighterAlt {
   background-color: $ms-color-neutralLighterAlt;
 }
+@mixin ms-bgColor-white {
+  background-color: $ms-color-white;
+}
 
 // Border
+@mixin ms-borderColor-black {
+  border-color: $ms-color-black;
+}
 @mixin ms-borderColor-neutralDark {
   border-color: $ms-color-neutralDark;
 }
@@ -168,8 +177,14 @@
 @mixin ms-borderColor-neutralLighterAlt {
   border-color: $ms-color-neutralLighterAlt;
 }
+@mixin ms-borderColor-white {
+  border-color: $ms-color-white;
+}
 
 // Font
+@mixin ms-fontColor-black {
+  color: $ms-color-black;
+}
 @mixin ms-fontColor-neutralDark {
   color: $ms-color-neutralDark;
 }
@@ -205,6 +220,9 @@
 }
 @mixin ms-fontColor-neutralLighterAlt {
   color: $ms-color-neutralLighterAlt;
+}
+@mixin ms-fontColor-white {
+  color: $ms-color-white;
 }
 
 //== Brand and accent colors

--- a/src/sass/variables/_Color.Variables.MDL2.scss
+++ b/src/sass/variables/_Color.Variables.MDL2.scss
@@ -13,6 +13,7 @@ $ms-color-themeLighterAlt: $ms-color-communicationTint40 !default;
 
 // Neutral
 // The original colors have been overridden by the new palette, with warmer grays.
+$ms-color-black: #000000 !default;
 $ms-color-neutralDark: $ms-color-gray190 !default;
 $ms-color-neutralPrimary: $ms-color-gray160 !default;
 $ms-color-neutralPrimaryAlt: $ms-color-gray150 !default;
@@ -25,6 +26,7 @@ $ms-color-neutralQuaternaryAlt: $ms-color-gray40 !default;
 $ms-color-neutralLight: $ms-color-gray30 !default;
 $ms-color-neutralLighter: $ms-color-gray20 !default;
 $ms-color-neutralLighterAlt: $ms-color-gray10 !default;
+$ms-color-white: #ffffff !default;
 
 // Accent
 // Where possible, these colors have been mapped to the new palette.


### PR DESCRIPTION
Adds black and white colors back to MDL2 variables and mixins. This supports the scenario where someone may be building a subset of Core and only want the MDL2 classes.