### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "4.1"
+  - 8
 notifications:
     email: false


### PR DESCRIPTION
Updates the Travis config to use the latest version of Node, fixing a build error (e.g. [this build](https://travis-ci.org/OfficeDev/office-ui-fabric-core/builds/434062279?utm_source=github_status&utm_medium=notification)). This change has been made on the Fluent branch and builds there have been stable ever since.