### PR TITLE
Fix missing edit (and other) icons

### DIFF
--- a/src/sass/mixins/_Icon.Mixins.scss
+++ b/src/sass/mixins/_Icon.Mixins.scss
@@ -84,9 +84,10 @@
 
       // Classes for the regular icon.
       .ms-Icon--#{$ltrIconName}::before {
-        @include ms-LTR {
-          content: $ltrIconCode;
-        }
+        // Avoid ms-LTR to prevent missing icons if HTML uses dir="auto" or omits attribute
+        content: $ltrIconCode;
+        
+        // Override content via increased specificity with the RTL selector
         @include ms-RTL {
           content: $iconCode;
         }
@@ -94,9 +95,10 @@
 
       // Classes for the mirrored icon.
       .ms-Icon--#{$iconName}::before {
-        @include ms-LTR {
-          content: $iconCode;
-        }
+        // Avoid ms-LTR to prevent missing icons if HTML uses dir="auto" or omits attribute
+        content: $iconCode;
+        
+        // Override content via increased specificity with the RTL selector
         @include ms-RTL {
           content: $ltrIconCode;
         }


### PR DESCRIPTION
Customers have complained that the Edit, Datetime and other icons are missing due to the added [dir='ltr'] selector that may not be in the customer's markup. Removing the scoping selector will allow for use of dir="auto" as well as avoid confusion that something might be broken