### PR TITLE
Fix SASS compilation error with ms-animation mixin

### DIFF
--- a/src/sass/mixins/_Animation.Mixins.MDL2.scss
+++ b/src/sass/mixins/_Animation.Mixins.MDL2.scss
@@ -174,7 +174,7 @@
   $namelist: ();
   @each $name in $names {
     $newname: $name#{$ms-fabric-version-suffix};
-    $namelist: append($namelist, unquote($newname), 'comma');
+    $namelist: append($namelist, $newname, 'comma');
   }
 
   // Output the animation's properties.


### PR DESCRIPTION
Fixes #1192.

SASS compilation error when using `dart-sass`. The now deprecated `node-sass` package didn't seem to catch this. SharePoint Online had to override locally when upgrading to `dart-sass`.

One can confirm with `dart-sass` using this interactive SASS playground with the fix: https://www.sassmeister.com/gist/d45db2cb08f43f703c727fd25c945f07?token=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&scope=gist,read:user